### PR TITLE
Fix lgtm.yml for LGTM.com C/C++ analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,15 +2,9 @@
 path_classifiers:
   test:
     - tests
-  docs:
-    - README.md
 extraction:
   cpp:
-    prepare:
-      packages:
-        - g++-6
-    # before_index:
     index:
       build_command:
         - cd ./tests
-        - $GNU_MAKE
+        - make


### PR DESCRIPTION
I noticed that you were trying to get C/C++ analysis working on LGTM.com. We're currently working on making debugging `lgtm.yml` settings easier, but let me give you a hand in the meantime. This setup works for me locally. I can trigger a retry on LGTM once this PR is merged.

Note that there is no need to classify `.md` files: those won't be scanned by LGTM. It should also install the right C/C++ compiler automagically.

(Full disclosure: I'm on the LGTM.com team :slightly_smiling_face:)