### PR TITLE
Replaced `BUILD_TESTS` option with `GCEM_BUILD_TESTS`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ install:
   - conda update -q conda
   - conda info -a
   - conda install cmake -c conda-forge
-  - cmake -G "NMake Makefiles" -D BUILD_TESTS=1 -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -D CMAKE_BUILD_TYPE=Release .
+  - cmake -G "NMake Makefiles" -D GCEM_BUILD_TESTS=1 -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -D CMAKE_BUILD_TYPE=Release .
   - nmake gcem_tests
   - cd tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,9 +107,9 @@ add_library(gcem INTERFACE)
 target_include_directories(gcem INTERFACE $<BUILD_INTERFACE:${GCEM_INCLUDE_DIR}>
                                           $<INSTALL_INTERFACE:include>)
 
-OPTION(BUILD_TESTS "gcem test suite" OFF)
+OPTION(GCEM_BUILD_TESTS "gcem test suite" OFF)
 
-if(BUILD_TESTS)
+if(GCEM_BUILD_TESTS)
     add_subdirectory(tests)
 endif()
 


### PR DESCRIPTION
When the library is used in another project, the more generic `BUILD_TESTS` might be already used, and building tests for libraries is not always desirable. This simple PR just changes that CMake option to `GCEM_BUILD_TESTS` so that the final user can selectively choose to build tests or not for each library.

By the way, great library!! It's awesome :D
