### PR TITLE
Fix log, log2, log10 for small arguments (fixes #30)

### DIFF
--- a/include/gcem_incl/log.hpp
+++ b/include/gcem_incl/log.hpp
@@ -108,8 +108,8 @@ noexcept
             // x < 0
             x < T(0) ? \
                 GCLIM<T>::quiet_NaN() :
-            // x ~= 0
-            GCLIM<T>::epsilon() > x ? \
+            // x == 0
+            x == T(0) ? \
                 - GCLIM<T>::infinity() :
             // indistinguishable from 1
             GCLIM<T>::epsilon() > abs(x - T(1)) ? \

--- a/include/gcem_incl/log10.hpp
+++ b/include/gcem_incl/log10.hpp
@@ -39,8 +39,8 @@ noexcept
             // x < 0
             x < T(0) ? \
                 GCLIM<T>::quiet_NaN() :
-            // x ~= 0
-            GCLIM<T>::epsilon() > x ? \
+            // x == 0
+            x == T(0) ? \
                 - GCLIM<T>::infinity() :
             // indistinguishable from 1
             GCLIM<T>::epsilon() > abs(x - T(1)) ? \

--- a/include/gcem_incl/log2.hpp
+++ b/include/gcem_incl/log2.hpp
@@ -39,8 +39,8 @@ noexcept
             // x < 0
             x < T(0) ? \
                 GCLIM<T>::quiet_NaN() :
-            // x ~= 0
-            GCLIM<T>::epsilon() > x ? \
+            // x == 0
+            x == T(0) ? \
                 - GCLIM<T>::infinity() :
             // indistinguishable from 1
             GCLIM<T>::epsilon() > abs(x - T(1)) ? \

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -38,6 +38,8 @@ int main()
     GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  41.5L);
     GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  0.0L);
     GCEM_TEST_COMPARE_VALS(gcem::log,std::log, -1.0L);
+    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  1e-500L);
+    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  std::numeric_limits<long double>::min());
     
     GCEM_TEST_COMPARE_VALS(gcem::log,std::log, -std::numeric_limits<long double>::infinity());
     GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  std::numeric_limits<long double>::infinity());

--- a/tests/log10.cpp
+++ b/tests/log10.cpp
@@ -35,6 +35,8 @@ int main()
     GCEM_TEST_COMPARE_VALS(gcem::log10, std::log10,  41.5L);
     GCEM_TEST_COMPARE_VALS(gcem::log10, std::log10,  0.0L);
     GCEM_TEST_COMPARE_VALS(gcem::log10, std::log10, -1.0L);
+    GCEM_TEST_COMPARE_VALS(gcem::log10, std::log10,  1e-500L);
+    GCEM_TEST_COMPARE_VALS(gcem::log10, std::log10,  std::numeric_limits<long double>::min());
     
     GCEM_TEST_COMPARE_VALS(gcem::log10, std::log10, -std::numeric_limits<long double>::infinity());
     GCEM_TEST_COMPARE_VALS(gcem::log10, std::log10,  std::numeric_limits<long double>::infinity());

--- a/tests/log2.cpp
+++ b/tests/log2.cpp
@@ -35,6 +35,8 @@ int main()
     GCEM_TEST_COMPARE_VALS(gcem::log2, std::log2,  41.5L);
     GCEM_TEST_COMPARE_VALS(gcem::log2, std::log2,  0.0L);
     GCEM_TEST_COMPARE_VALS(gcem::log2, std::log2, -1.0L);
+    GCEM_TEST_COMPARE_VALS(gcem::log2, std::log2,  1e-500L);
+    GCEM_TEST_COMPARE_VALS(gcem::log2, std::log2,  std::numeric_limits<long double>::min());
     
     GCEM_TEST_COMPARE_VALS(gcem::log2, std::log2, -std::numeric_limits<long double>::infinity());
     GCEM_TEST_COMPARE_VALS(gcem::log2, std::log2,  std::numeric_limits<long double>::infinity());


### PR DESCRIPTION
The different log implementations erroneously used `::epsilon()` to
check if the input argument was "roughly zero". However, especially
in case of the log function, you definitely want to be able to pass
arguments down to `std::numeric_limits<>::min()`.

This change replaces the check by a simple check against zero and
adds test cases to confirm the implementation works correctly down
to the smallest representable number.