### PR TITLE
makes the library windows compatible as min and max are predefined by…

### DIFF
--- a/include/gcem_incl/gcem_options.hpp
+++ b/include/gcem_incl/gcem_options.hpp
@@ -29,6 +29,14 @@
     #undef abs
 #endif
 
+#ifdef min
+    #undef min
+#endif
+
+#ifdef max
+    #undef max
+#endif
+
 #ifdef round
     #undef round
 #endif


### PR DESCRIPTION
windows automatically includes a header that defines min and max, this fixes that so gcem can be used with windows