### PR TITLE
Added rounding function handling for large numbers

### DIFF
--- a/include/gcem_incl/ceil.hpp
+++ b/include/gcem_incl/ceil.hpp
@@ -45,6 +45,57 @@ noexcept
 template<typename T>
 constexpr
 T
+ceil_check_internal(const T x)
+noexcept
+{
+    return x;
+}
+
+template<>
+constexpr
+float
+ceil_check_internal<float>(const float x)
+noexcept
+{
+    //threshold = 8388608.f;
+
+    return (
+        (abs(x) >= 8388608.f) ? \
+        x : \
+        ceil_int(x, float(static_cast<int>(x))) );
+}
+
+template<>
+constexpr
+double
+ceil_check_internal<double>(const double x)
+noexcept
+{
+    //threshold = 4503599627370496.;
+
+    return (
+        (abs(x) >= 4503599627370496.) ? \
+        x : \
+        ceil_int(x, double(static_cast<llint_t>(x))) );
+}
+
+template<>
+constexpr
+long double
+ceil_check_internal<long double>(const long double x)
+noexcept
+{
+    //threshold = 9223372036854775808.l;
+
+    return (
+        (abs(x) >= 9223372036854775808.l) ? \
+        x : \
+        ceil_int(x, ((long double)static_cast<ullint_t>(x)) * ((x < 0) ? -1.l : 1.l)) );
+}
+
+template<typename T>
+constexpr
+T
 ceil_check(const T x)
 noexcept
 {
@@ -58,7 +109,7 @@ noexcept
             GCLIM<T>::min() > abs(x) ? \
                 x :
             // else
-                ceil_int(x, T(static_cast<llint_t>(x))) );
+                ceil_check_internal(x) );
 }
 
 }

--- a/include/gcem_incl/ceil.hpp
+++ b/include/gcem_incl/ceil.hpp
@@ -90,7 +90,7 @@ noexcept
     return (
         (abs(x) >= 9223372036854775808.l) ? \
         x : \
-        ceil_int(x, ((long double)static_cast<ullint_t>(x)) * ((x < 0) ? -1.l : 1.l)) );
+        ceil_int(x, ((long double)static_cast<ullint_t>(abs(x))) * ((x < 0) ? -1.l : 1.l)) );
 }
 
 template<typename T>

--- a/include/gcem_incl/floor.hpp
+++ b/include/gcem_incl/floor.hpp
@@ -45,6 +45,57 @@ noexcept
 template<typename T>
 constexpr
 T
+floor_check_internal(const T x)
+noexcept
+{
+    return x;
+}
+
+template<>
+constexpr
+float
+floor_check_internal<float>(const float x)
+noexcept
+{
+    //threshold = 8388608.f;
+
+    return (
+        (abs(x) >= 8388608.f) ? \
+        x : \
+        floor_int(x, float(static_cast<int>(x))) );
+}
+
+template<>
+constexpr
+double
+floor_check_internal<double>(const double x)
+noexcept
+{
+    //threshold = 4503599627370496.;
+
+    return (
+        (abs(x) >= 4503599627370496.) ? \
+        x : \
+        floor_int(x, double(static_cast<llint_t>(x))) );
+}
+
+template<>
+constexpr
+long double
+floor_check_internal<long double>(const long double x)
+noexcept
+{
+    //threshold = 9223372036854775808.l;
+
+    return (
+        (abs(x) >= 9223372036854775808.l) ? \
+        x : \
+        floor_int(x, ((long double)static_cast<ullint_t>(x)) * ((x < 0) ? -1.l : 1.l)) );
+}
+
+template<typename T>
+constexpr
+T
 floor_check(const T x)
 noexcept
 {
@@ -58,7 +109,7 @@ noexcept
             GCLIM<T>::min() > abs(x) ? \
                 x :
             // else
-                floor_int(x, T(static_cast<llint_t>(x))) );
+                floor_check_internal(x) );
 }
 
 }

--- a/include/gcem_incl/floor.hpp
+++ b/include/gcem_incl/floor.hpp
@@ -90,7 +90,7 @@ noexcept
     return (
         (abs(x) >= 9223372036854775808.l) ? \
         x : \
-        floor_int(x, ((long double)static_cast<ullint_t>(x)) * ((x < 0) ? -1.l : 1.l)) );
+        floor_int(x, ((long double)static_cast<ullint_t>(abs(x))) * ((x < 0) ? -1.l : 1.l)) );
 }
 
 template<typename T>

--- a/include/gcem_incl/round.hpp
+++ b/include/gcem_incl/round.hpp
@@ -30,7 +30,64 @@ T
 round_int(const T x)
 noexcept
 {
-    return static_cast<T>(find_whole(x));
+    T floor_check_res = internal::floor_check(x);
+
+    return( abs(x - floor_check_res) >= T(0.5) ? \
+            // if 
+                floor_check_res + sgn(x) : \
+            // else 
+                floor_check_res );
+}
+
+template<typename T>
+constexpr
+T
+round_check_internal(const T x)
+noexcept
+{
+    return x;
+}
+
+template<>
+constexpr
+float
+round_check_internal<float>(const float x)
+noexcept
+{
+    //threshold = 8388608.f;
+
+    return (
+        (abs(x) >= 8388608.f) ? \
+        x : \
+        round_int(x) );
+}
+
+template<>
+constexpr
+double
+round_check_internal<double>(const double x)
+noexcept
+{
+    //threshold = 4503599627370496.;
+
+    return (
+        (abs(x) >= 4503599627370496.) ? \
+        x : \
+        round_int(x) );
+}
+
+template<>
+constexpr
+long double
+round_check_internal<long double>(const long double x)
+noexcept
+{
+    //threshold = 9223372036854775808.l;
+
+    return (
+        (abs(x) >= 9223372036854775808.l) ? \
+        x : \
+        round_int(x) );
 }
 
 template<typename T>

--- a/include/gcem_incl/round.hpp
+++ b/include/gcem_incl/round.hpp
@@ -30,13 +30,11 @@ T
 round_int(const T x)
 noexcept
 {
-    T floor_check_res = internal::floor_check(x);
-
-    return( abs(x - floor_check_res) >= T(0.5) ? \
+    return( abs(x - internal::floor_check(x)) >= T(0.5) ? \
             // if 
-                floor_check_res + sgn(x) : \
+                internal::floor_check(x) + sgn(x) : \
             // else 
-                floor_check_res );
+                internal::floor_check(x) );
 }
 
 template<typename T>

--- a/include/gcem_incl/trunc.hpp
+++ b/include/gcem_incl/trunc.hpp
@@ -36,6 +36,57 @@ noexcept
 template<typename T>
 constexpr
 T
+trunc_check_internal(const T x)
+noexcept
+{
+    return x;
+}
+
+template<>
+constexpr
+float
+trunc_check_internal<float>(const float x)
+noexcept
+{
+    //threshold = 8388608.f;
+
+    return (
+        (abs(x) >= 8388608.f) ? \
+        x : \
+        trunc_int(x) );
+}
+
+template<>
+constexpr
+double
+trunc_check_internal<double>(const double x)
+noexcept
+{
+    //threshold = 4503599627370496.;
+
+    return (
+        (abs(x) >= 4503599627370496.) ? \
+        x : \
+        trunc_int(x) );
+}
+
+template<>
+constexpr
+long double
+trunc_check_internal<long double>(const long double x)
+noexcept
+{
+    //threshold = 9223372036854775808.l;
+
+    return (
+        (abs(x) >= 9223372036854775808.l) ? \
+        x : \
+        ((long double)static_cast<ullint_t>(x)) * ((x < 0) ? -1.l : 1.l) );
+}
+
+template<typename T>
+constexpr
+T
 trunc_check(const T x)
 noexcept
 {
@@ -49,7 +100,7 @@ noexcept
             GCLIM<T>::min() > abs(x) ? \
                 x :
             // else
-                trunc_int(x) );
+                trunc_check_internal(x) );
 }
 
 }

--- a/include/gcem_incl/trunc.hpp
+++ b/include/gcem_incl/trunc.hpp
@@ -81,7 +81,7 @@ noexcept
     return (
         (abs(x) >= 9223372036854775808.l) ? \
         x : \
-        ((long double)static_cast<ullint_t>(x)) * ((x < 0) ? -1.l : 1.l) );
+        ((long double)static_cast<ullint_t>(abs(x))) * ((x < 0) ? -1.l : 1.l) );
 }
 
 template<typename T>

--- a/tests/rounding.cpp
+++ b/tests/rounding.cpp
@@ -38,6 +38,7 @@ int main()
     GCEM_TEST_COMPARE_VALS(gcem::floor,std::floor, -4.2);
     GCEM_TEST_COMPARE_VALS(gcem::floor,std::floor, -4.7);
     GCEM_TEST_COMPARE_VALS(gcem::floor,std::floor, -5.0);
+    GCEM_TEST_COMPARE_VALS(gcem::floor,std::floor, 42e32);
 
     GCEM_TEST_COMPARE_VALS(gcem::floor,std::floor,  std::numeric_limits<float>::max());
     GCEM_TEST_COMPARE_VALS(gcem::floor,std::floor, -std::numeric_limits<long double>::infinity());
@@ -55,6 +56,7 @@ int main()
     GCEM_TEST_COMPARE_VALS(gcem::ceil,std::ceil, -4.2);
     GCEM_TEST_COMPARE_VALS(gcem::ceil,std::ceil, -4.7);
     GCEM_TEST_COMPARE_VALS(gcem::ceil,std::ceil, -5.0);
+    GCEM_TEST_COMPARE_VALS(gcem::ceil,std::ceil, 42e32);
 
     GCEM_TEST_COMPARE_VALS(gcem::ceil,std::ceil,  std::numeric_limits<float>::max());
     GCEM_TEST_COMPARE_VALS(gcem::ceil,std::ceil, -std::numeric_limits<long double>::infinity());
@@ -72,6 +74,7 @@ int main()
     GCEM_TEST_COMPARE_VALS(gcem::trunc,std::trunc, -4.2);
     GCEM_TEST_COMPARE_VALS(gcem::trunc,std::trunc, -4.7);
     GCEM_TEST_COMPARE_VALS(gcem::trunc,std::trunc, -5.0);
+    GCEM_TEST_COMPARE_VALS(gcem::trunc,std::trunc, 42e32);
 
     GCEM_TEST_COMPARE_VALS(gcem::trunc,std::trunc,  std::numeric_limits<float>::max());
     GCEM_TEST_COMPARE_VALS(gcem::trunc,std::trunc, -std::numeric_limits<long double>::infinity());
@@ -90,6 +93,7 @@ int main()
     GCEM_TEST_COMPARE_VALS(gcem::round,std::round, -4.5);
     GCEM_TEST_COMPARE_VALS(gcem::round,std::round, -4.7);
     GCEM_TEST_COMPARE_VALS(gcem::round,std::round, -5.0);
+    GCEM_TEST_COMPARE_VALS(gcem::round,std::round, 42e32);
 
     GCEM_TEST_COMPARE_VALS(gcem::round,std::round,  std::numeric_limits<float>::max());
     GCEM_TEST_COMPARE_VALS(gcem::round,std::round, -std::numeric_limits<long double>::infinity());

--- a/tests/rounding.cpp
+++ b/tests/rounding.cpp
@@ -39,6 +39,7 @@ int main()
     GCEM_TEST_COMPARE_VALS(gcem::floor,std::floor, -4.7);
     GCEM_TEST_COMPARE_VALS(gcem::floor,std::floor, -5.0);
 
+    GCEM_TEST_COMPARE_VALS(gcem::floor,std::floor,  std::numeric_limits<float>::max());
     GCEM_TEST_COMPARE_VALS(gcem::floor,std::floor, -std::numeric_limits<long double>::infinity());
     GCEM_TEST_COMPARE_VALS(gcem::floor,std::floor,  std::numeric_limits<long double>::infinity());
     GCEM_TEST_COMPARE_VALS(gcem::floor,std::floor,  std::numeric_limits<long double>::quiet_NaN());
@@ -55,6 +56,7 @@ int main()
     GCEM_TEST_COMPARE_VALS(gcem::ceil,std::ceil, -4.7);
     GCEM_TEST_COMPARE_VALS(gcem::ceil,std::ceil, -5.0);
 
+    GCEM_TEST_COMPARE_VALS(gcem::ceil,std::ceil,  std::numeric_limits<float>::max());
     GCEM_TEST_COMPARE_VALS(gcem::ceil,std::ceil, -std::numeric_limits<long double>::infinity());
     GCEM_TEST_COMPARE_VALS(gcem::ceil,std::ceil,  std::numeric_limits<long double>::infinity());
     GCEM_TEST_COMPARE_VALS(gcem::ceil,std::ceil,  std::numeric_limits<long double>::quiet_NaN());
@@ -71,6 +73,7 @@ int main()
     GCEM_TEST_COMPARE_VALS(gcem::trunc,std::trunc, -4.7);
     GCEM_TEST_COMPARE_VALS(gcem::trunc,std::trunc, -5.0);
 
+    GCEM_TEST_COMPARE_VALS(gcem::trunc,std::trunc,  std::numeric_limits<float>::max());
     GCEM_TEST_COMPARE_VALS(gcem::trunc,std::trunc, -std::numeric_limits<long double>::infinity());
     GCEM_TEST_COMPARE_VALS(gcem::trunc,std::trunc,  std::numeric_limits<long double>::infinity());
     GCEM_TEST_COMPARE_VALS(gcem::trunc,std::trunc,  std::numeric_limits<long double>::quiet_NaN());
@@ -88,6 +91,7 @@ int main()
     GCEM_TEST_COMPARE_VALS(gcem::round,std::round, -4.7);
     GCEM_TEST_COMPARE_VALS(gcem::round,std::round, -5.0);
 
+    GCEM_TEST_COMPARE_VALS(gcem::round,std::round,  std::numeric_limits<float>::max());
     GCEM_TEST_COMPARE_VALS(gcem::round,std::round, -std::numeric_limits<long double>::infinity());
     GCEM_TEST_COMPARE_VALS(gcem::round,std::round,  std::numeric_limits<long double>::infinity());
     GCEM_TEST_COMPARE_VALS(gcem::round,std::round,  std::numeric_limits<long double>::quiet_NaN());


### PR DESCRIPTION
This pull request aims to resolve #16, which as also an issue for me as well, when I implemented this in my library, the threshold values were picked by running some tests on the floating point numbers themselves