### PR TITLE
Optimize install folder according to best practices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,18 +58,18 @@ OPTION(GCEM_BUILD_TESTS "gcem test suite" OFF)
 
 # install
 
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
 add_library(gcem INTERFACE)
 target_include_directories(gcem INTERFACE $<BUILD_INTERFACE:${GCEM_INCLUDE_DIR}>
-                                          $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
+                                          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
 
 if(GCEM_BUILD_TESTS)
     add_subdirectory(tests)
 endif()
 
 #
-
-include(CMakePackageConfigHelpers)
-include(GNUInstallDirs)
 
 install(
     TARGETS gcem

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ OPTION(GCEM_BUILD_TESTS "gcem test suite" OFF)
 
 add_library(gcem INTERFACE)
 target_include_directories(gcem INTERFACE $<BUILD_INTERFACE:${GCEM_INCLUDE_DIR}>
-                                          $<INSTALL_INTERFACE:include>)
+                                          $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 
 if(GCEM_BUILD_TESTS)
     add_subdirectory(tests)
@@ -80,7 +80,7 @@ export(EXPORT ${PROJECT_NAME}-targets
        FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
 
 install(DIRECTORY ${GCEM_INCLUDE_DIR}/
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 
 #
 


### PR DESCRIPTION
For some time now developers have established a convention for installing libraries. Include files should be in the system include folder (e.g. `/usr/local/include`) within a folder with the library name.
`/usr/local/include/<library name>/`

Currently the gcem library installs files (gcem.hpp and the folder gcem_incl) directly to `/usr/local/include`. It would be nicer to follow the convention.

I created a pull request that solves this. It still preserves backwards compatibility and will fill the cmake INTERFACE_INCLUDE_DIRECTORIES accordingly.