### PR TITLE
Fixed MSVC implicit conversion warnings

### DIFF
--- a/include/gcem_incl/atan.hpp
+++ b/include/gcem_incl/atan.hpp
@@ -83,9 +83,9 @@ atan_series_order(const T x, const T x_pow, const uint_t order, const uint_t max
 noexcept
 {
     return( max_order == 1 ? \
-                GCEM_HALF_PI - T(1)/x :
+                T(GCEM_HALF_PI) - T(1)/x :
             order == 1 ? \
-                GCEM_HALF_PI - T(1)/x + atan_series_order(x*x,pow(x,3),order+1,max_order) :
+                T(GCEM_HALF_PI) - T(1)/x + atan_series_order(x*x,pow(x,3),order+1,max_order) :
             // NOTE: x changes to x*x for order > 1
             order < max_order ? \
                 atan_series_order_calc(x,x_pow,order) \


### PR DESCRIPTION
This fixes MSVC C4244 warnings coming from atan.hpp.