### PR TITLE
issue 59: Fix decade boundary detection in find_exponent and mantissa for long double

### DIFF
--- a/include/gcem_incl/find_exponent.hpp
+++ b/include/gcem_incl/find_exponent.hpp
@@ -34,15 +34,21 @@ llint_t
 find_exponent(const T x, const llint_t exponent)
 noexcept
 {
+    // Subtract one epsilon from T(1) so that values whose x*10^n product lands
+    // within one epsilon below 1.0 (e.g. 0.001L in 80-bit, which rounds to
+    // ~0.5 eps below 1.0 after scaling by 1000) are not pushed into the wrong
+    // decade.  One epsilon is the unique correct choice: it must be > 0.5 eps
+    // to catch 0.001L, and < 1.5 eps to avoid misclassifying the next
+    // representable value below the boundary.
     return( // < 1
-            x < T(1e-03)  ? \
+            x * T(1000) < T(1) - GCLIM<T>::epsilon() ? \
                 find_exponent(x * T(1e+04), exponent - llint_t(4)) :
-            x < T(1e-01)  ? \
+            x * T(10) < T(1) - GCLIM<T>::epsilon() ? \
                 find_exponent(x * T(1e+02), exponent - llint_t(2)) :
-            x < T(1)  ? \
+            x < T(1) - GCLIM<T>::epsilon() ? \
                 find_exponent(x * T(10), exponent - llint_t(1)) :
             // > 10
-            x > T(10) ? \
+            x >= T(10) ? \
                 find_exponent(x / T(10), exponent + llint_t(1)) :
             x > T(1e+02) ? \
                 find_exponent(x / T(1e+02), exponent + llint_t(2)) :
@@ -51,6 +57,7 @@ noexcept
             // else
                 exponent );
 }
+
 
 }
 

--- a/include/gcem_incl/mantissa.hpp
+++ b/include/gcem_incl/mantissa.hpp
@@ -34,9 +34,13 @@ T
 mantissa(const T x)
 noexcept
 {
-    return( x < T(1) ? \
-                mantissa(x * T(10)) : 
-            x > T(10) ? \
+    // Mirror the one-epsilon tolerance used in find_exponent so that
+    // (mantissa(x), find_exponent(x)) stays a consistent decomposition of x.
+    return( x < T(1) - GCLIM<T>::epsilon() ? \
+                mantissa(x * T(10)) :
+            x < T(1) ? \
+                T(1) :
+            x >= T(10) ? \
                 mantissa(x / T(10)) :
             // else
                 x );

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -101,6 +101,9 @@ fabsl:
 factorial:
 	$(GCEM_MAKE_CALL)
 
+find_exponent:
+	$(GCEM_MAKE_CALL)
+
 fmod:
 	$(GCEM_MAKE_CALL)
 
@@ -138,6 +141,9 @@ log_binomial_coef:
 	$(GCEM_MAKE_CALL)
 
 log:
+	$(GCEM_MAKE_CALL)
+
+mantissa:
 	$(GCEM_MAKE_CALL)
 
 log1p:

--- a/tests/find_exponent.cpp
+++ b/tests/find_exponent.cpp
@@ -1,0 +1,59 @@
+/*################################################################################
+  ##
+  ##   Copyright (C) 2016-2026 Keith O'Hara
+  ##
+  ##   This file is part of the GCE-Math C++ library.
+  ##
+  ##   Licensed under the Apache License, Version 2.0 (the "License");
+  ##   you may not use this file except in compliance with the License.
+  ##   You may obtain a copy of the License at
+  ##
+  ##       http://www.apache.org/licenses/LICENSE-2.0
+  ##
+  ##   Unless required by applicable law or agreed to in writing, software
+  ##   distributed under the License is distributed on an "AS IS" BASIS,
+  ##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ##   See the License for the specific language governing permissions and
+  ##   limitations under the License.
+  ##
+  ################################################################################*/
+
+#define TEST_PRINT_PRECISION_1 6
+#define TEST_PRINT_PRECISION_2 18
+
+#include "gcem_tests.hpp"
+
+int main()
+{
+    print_begin("find_exponent");
+
+    // long double: positive exponents
+
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  0.0L,  1.0L,    0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  0.0L,  5.0L,    0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  1.0L,  10.0L,   0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  1.0L,  11.0L,   0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  1.0L,  99.9L,   0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  2.0L,  100.0L,  0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  2.0L,  200.0L,  0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  2.0L,  123.45L, 0LL);
+
+    // long double: negative exponents, including the boundary cases (0.1L and
+    // 0.001L round toward zero in 80-bit, placing them just below their nominal
+    // decade boundary)
+
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -1.0L,  0.5L,    0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -1.0L,  0.1L,    0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -2.0L,  0.01L,   0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -3.0L,  0.001L,  0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -4.0L,  2.0e-4L, 0LL);
+
+    // double: verify the same boundary values work for double
+
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -1.0L,  0.1,     0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -3.0L,  0.001,   0LL);
+
+    print_final("find_exponent");
+
+    return 0;
+}

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -1,6 +1,6 @@
 /*################################################################################
   ##
-  ##   Copyright (C) 2016-2024 Keith O'Hara
+  ##   Copyright (C) 2016-2026 Keith O'Hara
   ##
   ##   This file is part of the GCE-Math C++ library.
   ##
@@ -31,23 +31,25 @@ int main()
 
     //
 
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  0.5L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  0.00199900000000000208L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  1.0L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  1.5L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  41.5L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  123456789.5L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  0.001L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  0.1L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  0.5L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  0.00199900000000000208L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  1.0L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  1.5L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  41.5L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  123456789.5L);
 
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  0.0L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log, -1.0L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  0.0L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log, -1.0L);
 
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  1e-500L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  std::numeric_limits<long double>::min());
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  std::numeric_limits<double>::max());
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  1e-500L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  std::numeric_limits<long double>::min());
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  std::numeric_limits<double>::max());
     
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log, -std::numeric_limits<long double>::infinity());
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  std::numeric_limits<long double>::infinity());
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  std::numeric_limits<long double>::quiet_NaN());
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log, -std::numeric_limits<long double>::infinity());
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  std::numeric_limits<long double>::infinity());
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  std::numeric_limits<long double>::quiet_NaN());
 
     //
 

--- a/tests/mantissa.cpp
+++ b/tests/mantissa.cpp
@@ -1,0 +1,56 @@
+/*################################################################################
+  ##
+  ##   Copyright (C) 2016-2026 Keith O'Hara
+  ##
+  ##   This file is part of the GCE-Math C++ library.
+  ##
+  ##   Licensed under the Apache License, Version 2.0 (the "License");
+  ##   you may not use this file except in compliance with the License.
+  ##   You may obtain a copy of the License at
+  ##
+  ##       http://www.apache.org/licenses/LICENSE-2.0
+  ##
+  ##   Unless required by applicable law or agreed to in writing, software
+  ##   distributed under the License is distributed on an "AS IS" BASIS,
+  ##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ##   See the License for the specific language governing permissions and
+  ##   limitations under the License.
+  ##
+  ################################################################################*/
+
+#define TEST_PRINT_PRECISION_1 6
+#define TEST_PRINT_PRECISION_2 18
+
+#include "gcem_tests.hpp"
+
+int main()
+{
+    print_begin("mantissa");
+
+    // long double: values whose mantissa is unambiguous
+
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  1.0L,  1.0L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  5.0L,  5.0L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  9.99L, 9.99L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  2.0L,  20.0L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  1.2345L, 123.45L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  5.0L,  0.5L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  2.0L,  0.02L);
+
+    // long double: boundary cases withing the ULP-tolerant snap.  0.1L and
+    // 0.001L round toward zero in 80-bit, so repeated scaling by 10 lands just
+    // below 1.0 rather than exactly on it.  mantissa() must snap these to 1.0
+    // to stay consistent with find_exponent().
+
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  1.0L,  0.1L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  1.0L,  0.001L);
+
+    // double: verify the same boundary values work for double
+
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  1.0,   0.1);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  1.0,   0.001);
+
+    print_final("mantissa");
+
+    return 0;
+}

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -1,4 +1,6 @@
 
+set -e
+
 for t in ./*.test; do
    "$t"
 done


### PR DESCRIPTION
# Description

This corrects https://github.com/kthohr/gcem/issues/59 (and additionally https://github.com/kthohr/gcem/issues/44), which discusses in detail the bug corrected by this PR.

There are 4 fixes here:

1. A simple change to allow pipelines to actually fail.
2. An update to `gcem::find_exponent` to correctly calculate the exponent for `long doubles` for values that lie at the boundary used to find the exponent.
3. An update to `gcem::mantissa` that does the same as (2).
4. An update to `gcem::find_exponent` and `gcem::mantissa` to correctly handle exact decade boundaries (`10.0L`, `100.0L`).

I also updated 3 tests:

1. Tests added to cover `gcem::find_exponent`.
2. Tests added to cover `gcem::mantissa`.
3. Tests added to `gcem::log` to cover edge cases.

# Changes

The fix here is two-fold. First, values are scaled up so that the comparison threshold becomes an exact integer T(1), rather than the imprecise T(1e-03) literal. This is the x * T(10) and x * T(1000) portions. Because T(1) is exactly represnteable, the rounding issue of T(1e-03) goes away. Second, they are compared against 1 - machine epsilon, so that values whose scaled representation falls just below 1 due to rounding are still guaranteed to fall into the correct decade. This is tabulated below:


| x range          | condition            | jump   | snap zone                          |
|------------------|----------------------|--------|------------------------------------|
| x < 0.001        | x * 1000 < 1 - eps   | x10000 | x * 1000 in [1-eps, 1), 1 ULP wide |
| 0.001 <= x < 0.1 | x * 10   < 1 - eps   | x100   | x * 10   in [1-eps, 1), 1 ULP wide |
| 0.1 <= x < 1     | x        < 1 - eps   | x10    | x        in [1-eps, 1), 1 ULP wide |

This gives a "snap zone" of 1 ULP below each scaled boundary. Real numbers that fall within this zone cannot be distinguished from the boundary at long double precision, so they snap "up" to T(1).

A similar technique is implemented in `gcem::mantissa`, although sans the scaling because that function on checks for bounding cases between 1 and 10.

```
x < T(1) - GCLIM<T>::epsilon()  ->  mantissa(x * T(10))
"x is genuinely below 1, scale up and recurse"

x < T(1) -> T(1)
"x is within one epsilon of 1 from below. Close enough, snap to 1"

x >= T(10) ->  mantissa(x / T(10))
"x is 10 or above, scale down and recurse"

x
"x is in [1, 10], this is the mantissa, return it"
```

After a lot of thought and testing, I'm pretty convinced that `gcem::find_exponent` originally returned incorrect values for every odd negative of power 10 (i.e. 10^-1,  10^-3, 10^-5, etc...) for `long double`. I think the reason for the alternating pattern is that the value cascades through both broken thresholds (T(1e-03) and T(1e-01)), scaling through each in turn until the final product lands just below 10.0, where the > T(10) branch that would otherwise fix the exponent cannot be taken (b/c of the rounding). So even powers of 10 are rounded but in a way that they take the correct branch.

I also fixed a separate simpler issue: both `gcem::find_exponent` and `gcem::mantissa` used a strict x > T(10) comparison for the downscaling branch. Since `10.0L` and `100.0L` are exactly representable, they fell through to the base case, returning an exponent one too low. Changing > to >= fixes this. Unlike the odd-power bug, this did not produce an incorrect log output.
