### PR TITLE
Dockerize CI to pin compiler dependencies and fix coverage pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,129 +4,122 @@
 
 name: CI
 
-on: [push, pull_request, release]
+on:
+  push:
+  pull_request:
+  release:
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at midnight UTC
 
 jobs:
-  build:
+  build-linux:
     name: ${{ matrix.config.name }}
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ubuntu-latest
+    container: ghcr.io/mitchellthompkins/gcem/ci:eb24b0547d0f
 
     strategy:
       fail-fast: false
       matrix:
-        config: 
+        config:
         - {
-            name: "ubuntu_latest_gcc_cxx11",
-            os: ubuntu-latest,
+            name: "gcc12_cxx11",
             build_type: "Release",
-            cc: "gcc",
-            cxx: "g++",
+            cc: "gcc-12",
+            cxx: "g++-12",
             cxxstd: "11"
           }
         - {
-            name: "ubuntu_latest_gcc_cxx11_coverage",
-            os: ubuntu-latest,
+            name: "gcc12_cxx11_coverage",
             build_type: "Coverage",
-            cc: "gcc",
-            cxx: "g++",
+            cc: "gcc-12",
+            cxx: "g++-12",
             cxxstd: "11"
           }
         - {
-            name: "ubuntu_latest_gcc9_cxx14",
-            os: ubuntu-latest,
+            name: "gcc9_cxx14",
             build_type: "Release",
             cc: "gcc-9",
             cxx: "g++-9",
             cxxstd: "14"
           }
         - {
-            name: "ubuntu_latest_gcc10_cxx14",
-            os: ubuntu-latest,
+            name: "gcc10_cxx14",
             build_type: "Release",
             cc: "gcc-10",
             cxx: "g++-10",
             cxxstd: "14"
           }
         - {
-            name: "ubuntu_latest_gcc11_cxx17",
-            os: ubuntu-latest,
+            name: "gcc11_cxx17",
             build_type: "Release",
             cc: "gcc-11",
             cxx: "g++-11",
             cxxstd: "17"
           }
         - {
-            name: "ubuntu_latest_gcc11_cxx20",
-            os: ubuntu-latest,
+            name: "gcc11_cxx20",
             build_type: "Release",
             cc: "gcc-11",
             cxx: "g++-11",
             cxxstd: "20"
           }
         - {
-            name: "ubuntu_latest_clang11_cxx11",
-            os: ubuntu-latest,
+            name: "clang11_cxx11",
             build_type: "Release",
             cc: "clang-11",
             cxx: "clang++-11",
             cxxstd: "11"
           }
         - {
-            name: "ubuntu_latest_clang11_cxx14",
-            os: ubuntu-latest,
+            name: "clang11_cxx14",
             build_type: "Release",
             cc: "clang-11",
             cxx: "clang++-11",
             cxxstd: "14"
           }
         - {
-            name: "ubuntu_latest_clang12_cxx14",
-            os: ubuntu-latest,
+            name: "clang12_cxx14",
             build_type: "Release",
             cc: "clang-12",
             cxx: "clang++-12",
             cxxstd: "14"
           }
         - {
-            name: "ubuntu22_clang13_cxx17",
-            os: ubuntu-22.04,
+            name: "clang13_cxx17",
             build_type: "Release",
             cc: "clang-13",
             cxx: "clang++-13",
             cxxstd: "17"
           }
         - {
-            name: "ubuntu22_clang14_cxx20",
-            os: ubuntu-22.04,
+            name: "clang14_cxx20",
             build_type: "Release",
             cc: "clang-14",
             cxx: "clang++-14",
             cxxstd: "20"
           }
         - {
-            name: "macos_latest_clang_cxx11",
-            os: macos-latest,
+            name: "gcc13_cxx23",
             build_type: "Release",
-            cc: "clang",
-            cxx: "clang++",
-            cxxstd: "11"
+            cc: "gcc-13",
+            cxx: "g++-13",
+            cxxstd: "23"
+          }
+        - {
+            name: "clang16_cxx23",
+            build_type: "Release",
+            cc: "clang-16",
+            cxx: "clang++-16",
+            cxxstd: "2b"
           }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Print env
         run: |
           echo github.event.action: ${{ github.event.action }}
           echo github.event_name: ${{ github.event_name }}
-
-      - name: Install dependencies on ubuntu
-        if: startsWith(matrix.config.name, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install ${{ matrix.config.cc }} ${{ matrix.config.cxx }}
-          ${{ matrix.config.cc }} --version
-          echo "CXXT=${{ matrix.config.cxxstd }}" >> $GITHUB_ENV
 
       - name: Tests
         shell: bash
@@ -135,24 +128,52 @@ jobs:
           export CC=${{ matrix.config.cc }}
           export CXX=${{ matrix.config.cxx }}
           export GCEM_CXX_STD="-std=c++${{ matrix.config.cxxstd }}"
-          echo "Testing CXXT: ${CXXT}"
-          echo "Testing env.CXXT: ${{ env.CXXT }}"
+          export COVERAGE=${{ matrix.config.build_type == 'Coverage' && '1' || '' }}
           make
           ./run_tests
 
       - name: Coverage
-        if: startsWith(matrix.config.build_type, 'Coverage')
+        if: matrix.config.build_type == 'Coverage'
         shell: bash
         working-directory: tests
         run: |
-          export SHOULD_RUN_COVERAGE="y"
-          ./cov_check
-          cd ..
-          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-          gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-          shasum -a 256 -c codecov.SHA256SUM
-          chmod +x codecov
-          ./codecov
+          CC="${{ matrix.config.cc }}"
+          lcov --gcov-tool "${CC/gcc/gcov}" --directory . --capture --output-file coverage.info
+
+      - name: Upload coverage to Codecov
+        if: matrix.config.build_type == 'Coverage'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          name: gcem
+          files: ${{ github.workspace }}/tests/coverage.info
+          verbose: true
+
+  build-macos:
+    name: macos_latest_clang_cxx${{ matrix.cxxstd }}
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cxxstd: ["11", "14", "17", "20", "23"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Print env
+        run: |
+          echo github.event.action: ${{ github.event.action }}
+          echo github.event_name: ${{ github.event_name }}
+
+      - name: Tests
+        shell: bash
+        working-directory: tests
+        run: |
+          export CC=clang
+          export CXX=clang++
+          export GCEM_CXX_STD="-std=c++${{ matrix.cxxstd }}"
+          make clean
+          make
+          ./run_tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
           }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # actions/checkout@v6.0.3
 
       - name: Print env
         run: |
@@ -160,7 +160,7 @@ jobs:
         cxxstd: ["11", "14", "17", "20", "23"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # actions/checkout@v6.0.3
 
       - name: Print env
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.config.build_type == 'Coverage'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+## Running CI Locally
+
+Build the CI image:
+
+```bash
+docker build -t gcem/ci:latest .
+```
+
+Run the full compiler matrix against your local changes:
+
+```bash
+./run-local-ci.sh
+```
+
+## Updating the CI Image
+
+After editing the Dockerfile, verify it locally with the steps above, then publish:
+
+```bash
+GHRCIO_TOKEN=<token> ./publish-ci-image.sh
+```
+
+This builds the image, pushes it to the registry tagged with the Dockerfile's
+content hash, and updates the tag in `.github/workflows/main.yml`. Commit the
+Dockerfile and the updated `main.yml` together.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# CI build environment for gcem.
+# Contains all Linux compiler variants: gcc-9/10/11/12/13 and clang-11/12/13/14/16.
+#
+# ubuntu:20.04 (focal) is required — Ubuntu 22.04 dropped clang-11 and clang-12
+# from apt.llvm.org. The ubuntu-toolchain-r PPA provides gcc-11 through gcc-13
+# on focal.
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gnupg \
+        software-properties-common \
+        wget \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor \
+       > /usr/share/keyrings/llvm-archive-keyring.gpg \
+    && for V in 11 12 13 14 16; do \
+         echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] \
+           http://apt.llvm.org/focal/ llvm-toolchain-focal-${V} main" \
+           >> /etc/apt/sources.list.d/llvm.list; \
+       done \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        make \
+        gcc-9  g++-9  \
+        gcc-10 g++-10 \
+        gcc-11 g++-11 \
+        gcc-12 g++-12 \
+        gcc-13 g++-13 \
+        clang-11 clang-12 clang-13 clang-14 clang-16 \
+        lcov \
+    && rm -rf /var/lib/apt/lists/*

--- a/publish-ci-image.sh
+++ b/publish-ci-image.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Builds the CI image, pushes it to ghcr.io, and updates the image tag in
+# main.yml. Run this after editing the Dockerfile and verifying with
+# run-local-ci.sh.
+#
+# Usage: GHRCIO_TOKEN=<token> ./publish-ci-image.sh
+set -euo pipefail
+
+: "${GHRCIO_TOKEN:?GHRCIO_TOKEN is not set}"
+
+REGISTRY="ghcr.io"
+REPO="mitchellthompkins/gcem"
+IMAGE="${REGISTRY}/${REPO}/ci"
+WORKFLOW=".github/workflows/main.yml"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+TAG="$(sha256sum Dockerfile | cut -c1-12)"
+echo "Tag: $TAG"
+
+echo "Building ${IMAGE}:${TAG} ..."
+docker build -t "${IMAGE}:${TAG}" .
+
+echo "Logging in to ${REGISTRY} ..."
+echo "${GHRCIO_TOKEN}" | docker login "${REGISTRY}" -u MitchellThompkins --password-stdin
+
+echo "Pushing ${IMAGE}:${TAG} ..."
+docker push "${IMAGE}:${TAG}"
+
+echo "Updating $WORKFLOW ..."
+sed -i "s|${IMAGE}:[^[:space:]]*|${IMAGE}:${TAG}|g" "$WORKFLOW"
+
+echo "Done. Commit Dockerfile and $WORKFLOW together."

--- a/run-local-ci.sh
+++ b/run-local-ci.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Mirrors the build-linux job in .github/workflows/main.yml.
+# Each matrix entry runs in its own fresh container, matching CI behaviour.
+set -euo pipefail
+
+IMAGE="gcem/ci:latest"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# name, build_type, cc, cxx, cxxstd
+MATRIX=(
+  "gcc12_cxx11          Release  gcc-12     g++-12     11"
+  "gcc12_cxx11_coverage Coverage gcc-12     g++-12     11"
+  "gcc9_cxx14           Release  gcc-9      g++-9      14"
+  "gcc10_cxx14          Release  gcc-10     g++-10     14"
+  "gcc11_cxx17          Release  gcc-11     g++-11     17"
+  "gcc11_cxx20          Release  gcc-11     g++-11     20"
+  "clang11_cxx11        Release  clang-11   clang++-11 11"
+  "clang11_cxx14        Release  clang-11   clang++-11 14"
+  "clang12_cxx14        Release  clang-12   clang++-12 14"
+  "clang13_cxx17        Release  clang-13   clang++-13 17"
+  "clang14_cxx20        Release  clang-14   clang++-14 20"
+  "gcc13_cxx23          Release  gcc-13     g++-13     23"
+  "clang16_cxx23        Release  clang-16   clang++-16 2b"
+)
+
+PASS=()
+FAIL=()
+
+for entry in "${MATRIX[@]}"; do
+  read -r name build_type cc cxx cxxstd <<< "$entry"
+
+  echo ""
+  echo "-> $name"
+
+  coverage=$([[ "$build_type" == "Coverage" ]] && echo "1" || echo "")
+
+  if docker run --rm -v "${REPO}:/src" -w /src/tests "$IMAGE" bash -c "
+    export CC=$cc
+    export CXX=$cxx
+    export GCEM_CXX_STD=-std=c++$cxxstd
+    export COVERAGE=$coverage
+    make clean
+    make
+    ./run_tests
+  "; then
+    PASS+=("$name")
+  else
+    FAIL+=("$name")
+  fi
+done
+
+echo ""
+for name in "${PASS[@]}"; do echo "PASS  $name"; done
+for name in "${FAIL[@]}"; do echo "FAIL  $name"; done
+echo ""
+
+[ ${#FAIL[@]} -eq 0 ]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,9 +11,13 @@ else
 endif
 
 ifneq (,$(findstring clang,$(CXX)))
-	OPT_FLAGS = -g -O0 -Wall -Wextra --coverage -fno-inline
+	OPT_FLAGS = -g -O0 -Wall -Wextra -fno-inline
 else
-	OPT_FLAGS = -g -O0 -Wall -Wextra --coverage -fno-inline -fno-inline-small-functions -fno-default-inline
+	OPT_FLAGS = -g -O0 -Wall -Wextra -fno-inline -fno-inline-small-functions -fno-default-inline
+endif
+
+ifneq (,$(COVERAGE))
+	OPT_FLAGS += --coverage
 endif
 
 ifneq ($(TRAVIS_CLANG_BUILD),)


### PR DESCRIPTION
# Summary

This PR Dockerizes all test dependencies in an effort to make the pipeline more robust and run at regular intervals (if only because I have a pathological need to see green pipelines). It maintains support for older compiler versions and fixes the code coverage pipelines. It also adds more `macos` clang support for fun. As part of this dockerization it publishes its own test container to pin down dependencies; though this does require a manual step in order to maintain said container.

The original cov_check script called gcov directly on each `.cpp` file to locate and process its associated .gcda data, which is the low-level way to generate coverage data. lcov with `--gcov-tool gcov-12` and `--capture` does the equivalent by automatically scanning for .gcda and acts as a wrapper around gcov. It does the same thing but produces a standardized output format (`coverage.info`) that [Codecov.io](https://about.codecov.io/) expects. I switched because the current pipeline was failing and the Codecov uploader needed a standard format file anyway. lcov solved both problems at once.

With https://github.com/kthohr/gcem/pull/58 @marcizhu implemented some similar non-Docker based solutions and does a good job (I stole their lcov idea but still invoke gcov under the hood just to maintain consistency), but I'm partial to my solution here because it preserves testing support for older compilers and c++ versions and makes the CI environment more controlled and less dependent on upstream changes.

As supporting work I added some silly script to use the same CI environment locally and some supporting documentation for all of the above in `CONTRIBUTING.md`.

Notably I didn't update the minimum `CMake` version b/c that seems like an orthogonal change to me. I prefer the solution by @BartolomeyKant in https://github.com/kthohr/gcem/pull/54 to https://github.com/kthohr/gcem/pull/58 because I think the floor for a Cmake minimum for a header-only library is actually very low and I like keeping compatibility boundaries wide (mostly b/c I work on outdated embedded system platforms); but that's just my opinion.

## Project Owner TODOs

@kthor If you choose to consume this PR you'll need to do the following to make this work:

1. Create a GitHub Classic personal access token with `write:packages` scope to authenticate the push to ghcr.io.
2. Set the ghcr.io package to public. `GitHub -> Profile -> Packages -> gcem/ci -> Package settings -> Change visibility -> Public`, so CI runners can pull without authentication.
3. Set up (or re-setup) Codecov. Connect the repo at codecov.io, get a  `CODECOV_TOKEN`, and add it as a GitHub Actions secret (`Settings -> Secrets -> Actions`).
4. Update `publish-ci-image.sh`. The docker login line hardcodes `MitchellThompkins` as the username. You would need to change it to your own GitHub username.
5. Rebuild and publish the CI image under your own account by running `publish-ci-image.sh`. The image is currently at `ghcr.io/mitchellthompkins/gcem/ci` and should move to `ghcr.io/kthohr/gcem/ci` The script also updates the reference in main.yml automatically.


# Changes

- Dockerizes the Linux CI pipeline to permanently pin compiler dependencies. The previous workflow installed compilers at runtime via `apt-get` on `ubuntu-latest`, which was actively broken: `clang-11` and `clang-12` were no longer available on Ubuntu 24.04.
- Adds a weekly scheduled CI run.
- Fixes coverage collection, which was failing due to a manual codecov uploader script.
- Adds supporting scripts for pushing the docker container and for using that container to test locally.
- Massages `tests/Makefile` slightly to support this updated workflow.
- Adds a `CONTRIBUTING.md` to capture some of how to test and update the container.

**Note**: These pipelines actually pass on test failures today, and will until https://github.com/kthohr/gcem/issues/59 is resolved. 2ff0096c513b887d6c6db3581e24579df66db30b has the required changed for that.
