### PR TITLE
Add optional no-stdlib mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,129 +4,122 @@
 
 name: CI
 
-on: [push, pull_request, release]
+on:
+  push:
+  pull_request:
+  release:
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at midnight UTC
 
 jobs:
-  build:
+  build-linux:
     name: ${{ matrix.config.name }}
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ubuntu-latest
+    container: ghcr.io/mitchellthompkins/gcem/ci:eb24b0547d0f
 
     strategy:
       fail-fast: false
       matrix:
-        config: 
+        config:
         - {
-            name: "ubuntu_latest_gcc_cxx11",
-            os: ubuntu-latest,
+            name: "gcc12_cxx11",
             build_type: "Release",
-            cc: "gcc",
-            cxx: "g++",
+            cc: "gcc-12",
+            cxx: "g++-12",
             cxxstd: "11"
           }
         - {
-            name: "ubuntu_latest_gcc_cxx11_coverage",
-            os: ubuntu-latest,
+            name: "gcc12_cxx11_coverage",
             build_type: "Coverage",
-            cc: "gcc",
-            cxx: "g++",
+            cc: "gcc-12",
+            cxx: "g++-12",
             cxxstd: "11"
           }
         - {
-            name: "ubuntu_latest_gcc9_cxx14",
-            os: ubuntu-latest,
+            name: "gcc9_cxx14",
             build_type: "Release",
             cc: "gcc-9",
             cxx: "g++-9",
             cxxstd: "14"
           }
         - {
-            name: "ubuntu_latest_gcc10_cxx14",
-            os: ubuntu-latest,
+            name: "gcc10_cxx14",
             build_type: "Release",
             cc: "gcc-10",
             cxx: "g++-10",
             cxxstd: "14"
           }
         - {
-            name: "ubuntu_latest_gcc11_cxx17",
-            os: ubuntu-latest,
+            name: "gcc11_cxx17",
             build_type: "Release",
             cc: "gcc-11",
             cxx: "g++-11",
             cxxstd: "17"
           }
         - {
-            name: "ubuntu_latest_gcc11_cxx20",
-            os: ubuntu-latest,
+            name: "gcc11_cxx20",
             build_type: "Release",
             cc: "gcc-11",
             cxx: "g++-11",
             cxxstd: "20"
           }
         - {
-            name: "ubuntu_latest_clang11_cxx11",
-            os: ubuntu-latest,
+            name: "clang11_cxx11",
             build_type: "Release",
             cc: "clang-11",
             cxx: "clang++-11",
             cxxstd: "11"
           }
         - {
-            name: "ubuntu_latest_clang11_cxx14",
-            os: ubuntu-latest,
+            name: "clang11_cxx14",
             build_type: "Release",
             cc: "clang-11",
             cxx: "clang++-11",
             cxxstd: "14"
           }
         - {
-            name: "ubuntu_latest_clang12_cxx14",
-            os: ubuntu-latest,
+            name: "clang12_cxx14",
             build_type: "Release",
             cc: "clang-12",
             cxx: "clang++-12",
             cxxstd: "14"
           }
         - {
-            name: "ubuntu22_clang13_cxx17",
-            os: ubuntu-22.04,
+            name: "clang13_cxx17",
             build_type: "Release",
             cc: "clang-13",
             cxx: "clang++-13",
             cxxstd: "17"
           }
         - {
-            name: "ubuntu22_clang14_cxx20",
-            os: ubuntu-22.04,
+            name: "clang14_cxx20",
             build_type: "Release",
             cc: "clang-14",
             cxx: "clang++-14",
             cxxstd: "20"
           }
         - {
-            name: "macos_latest_clang_cxx11",
-            os: macos-latest,
+            name: "gcc13_cxx23",
             build_type: "Release",
-            cc: "clang",
-            cxx: "clang++",
-            cxxstd: "11"
+            cc: "gcc-13",
+            cxx: "g++-13",
+            cxxstd: "23"
+          }
+        - {
+            name: "clang16_cxx23",
+            build_type: "Release",
+            cc: "clang-16",
+            cxx: "clang++-16",
+            cxxstd: "2b"
           }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Print env
         run: |
           echo github.event.action: ${{ github.event.action }}
           echo github.event_name: ${{ github.event_name }}
-
-      - name: Install dependencies on ubuntu
-        if: startsWith(matrix.config.name, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install ${{ matrix.config.cc }} ${{ matrix.config.cxx }}
-          ${{ matrix.config.cc }} --version
-          echo "CXXT=${{ matrix.config.cxxstd }}" >> $GITHUB_ENV
 
       - name: Tests
         shell: bash
@@ -135,24 +128,52 @@ jobs:
           export CC=${{ matrix.config.cc }}
           export CXX=${{ matrix.config.cxx }}
           export GCEM_CXX_STD="-std=c++${{ matrix.config.cxxstd }}"
-          echo "Testing CXXT: ${CXXT}"
-          echo "Testing env.CXXT: ${{ env.CXXT }}"
+          export COVERAGE=${{ matrix.config.build_type == 'Coverage' && '1' || '' }}
           make
           ./run_tests
 
       - name: Coverage
-        if: startsWith(matrix.config.build_type, 'Coverage')
+        if: matrix.config.build_type == 'Coverage'
         shell: bash
         working-directory: tests
         run: |
-          export SHOULD_RUN_COVERAGE="y"
-          ./cov_check
-          cd ..
-          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-          gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-          shasum -a 256 -c codecov.SHA256SUM
-          chmod +x codecov
-          ./codecov
+          CC="${{ matrix.config.cc }}"
+          lcov --gcov-tool "${CC/gcc/gcov}" --directory . --capture --output-file coverage.info
+
+      - name: Upload coverage to Codecov
+        if: matrix.config.build_type == 'Coverage'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          name: gcem
+          files: ${{ github.workspace }}/tests/coverage.info
+          verbose: true
+
+  build-macos:
+    name: macos_latest_clang_cxx${{ matrix.cxxstd }}
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cxxstd: ["11", "14", "17", "20", "23"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Print env
+        run: |
+          echo github.event.action: ${{ github.event.action }}
+          echo github.event_name: ${{ github.event_name }}
+
+      - name: Tests
+        shell: bash
+        working-directory: tests
+        run: |
+          export CC=clang
+          export CXX=clang++
+          export GCEM_CXX_STD="-std=c++${{ matrix.cxxstd }}"
+          make clean
+          make
+          ./run_tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
           echo github.event.action: ${{ github.event.action }}
           echo github.event_name: ${{ github.event_name }}
 
-      - name: Tests
+      - name: Tests (stdlib)
         shell: bash
         working-directory: tests
         run: |
@@ -129,7 +129,21 @@ jobs:
           export CXX=${{ matrix.config.cxx }}
           export GCEM_CXX_STD="-std=c++${{ matrix.config.cxxstd }}"
           export COVERAGE=${{ matrix.config.build_type == 'Coverage' && '1' || '' }}
+          make clean
           make
+          ./run_tests
+
+      - name: Tests (builtin traits / no stdlib)
+        # Skipped for Coverage builds: coverage is already captured by the stdlib run above.
+        if: matrix.config.build_type != 'Coverage'
+        shell: bash
+        working-directory: tests
+        run: |
+          export CC=${{ matrix.config.cc }}
+          export CXX=${{ matrix.config.cxx }}
+          export GCEM_CXX_STD="-std=c++${{ matrix.config.cxxstd }}"
+          make clean
+          GCEM_TRAITS_FLAGS="-DGCEM_TRAITS_BUILTIN" make
           ./run_tests
 
       - name: Coverage
@@ -167,7 +181,7 @@ jobs:
           echo github.event.action: ${{ github.event.action }}
           echo github.event_name: ${{ github.event_name }}
 
-      - name: Tests
+      - name: Tests (stdlib)
         shell: bash
         working-directory: tests
         run: |
@@ -176,4 +190,15 @@ jobs:
           export GCEM_CXX_STD="-std=c++${{ matrix.cxxstd }}"
           make clean
           make
+          ./run_tests
+
+      - name: Tests (builtin traits / no stdlib)
+        shell: bash
+        working-directory: tests
+        run: |
+          export CC=clang
+          export CXX=clang++
+          export GCEM_CXX_STD="-std=c++${{ matrix.cxxstd }}"
+          make clean
+          GCEM_TRAITS_FLAGS="-DGCEM_TRAITS_BUILTIN" make
           ./run_tests

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ docs/xml
 *.gcno
 *.gcov
 *.dSYM
+*.sw[op]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+## Running CI Locally
+
+Build the CI image:
+
+```bash
+docker build -t gcem/ci:latest .
+```
+
+Run the full compiler matrix against your local changes:
+
+```bash
+./run-local-ci.sh
+```
+
+## Updating the CI Image
+
+After editing the Dockerfile, verify it locally with the steps above, then publish:
+
+```bash
+GHRCIO_TOKEN=<token> ./publish-ci-image.sh
+```
+
+This builds the image, pushes it to the registry tagged with the Dockerfile's
+content hash, and updates the tag in `.github/workflows/main.yml`. Commit the
+Dockerfile and the updated `main.yml` together.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# CI build environment for gcem.
+# Contains all Linux compiler variants: gcc-9/10/11/12/13 and clang-11/12/13/14/16.
+#
+# ubuntu:20.04 (focal) is required — Ubuntu 22.04 dropped clang-11 and clang-12
+# from apt.llvm.org. The ubuntu-toolchain-r PPA provides gcc-11 through gcc-13
+# on focal.
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gnupg \
+        software-properties-common \
+        wget \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor \
+       > /usr/share/keyrings/llvm-archive-keyring.gpg \
+    && for V in 11 12 13 14 16; do \
+         echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] \
+           http://apt.llvm.org/focal/ llvm-toolchain-focal-${V} main" \
+           >> /etc/apt/sources.list.d/llvm.list; \
+       done \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        make \
+        gcc-9  g++-9  \
+        gcc-10 g++-10 \
+        gcc-11 g++-11 \
+        gcc-12 g++-12 \
+        gcc-13 g++-13 \
+        clang-11 clang-12 clang-13 clang-14 clang-16 \
+        lcov \
+    && rm -rf /var/lib/apt/lists/*

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -83,5 +83,11 @@ To build the full test suite:
     git clone -b master --single-branch https://github.com/kthohr/gcem ./gcem
     # compile tests
     cd ./gcem/tests
+
+    # default mode: uses <limits> and <type_traits> from the hosted stdlib
     make
+    ./run_tests
+
+    # builtin mode: self-contained, no stdlib required (GCC, Clang, and modern MSVC)
+    make GCEM_TRAITS_FLAGS="-DGCEM_TRAITS_BUILTIN"
     ./run_tests

--- a/include/gcem_incl/binomial_coef.hpp
+++ b/include/gcem_incl/binomial_coef.hpp
@@ -37,7 +37,7 @@ noexcept
                 binomial_coef_recur(n-1,k-1) + binomial_coef_recur(n-1,k) );
 }
 
-template<typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+template<typename T, typename enable_if<is_integral<T>::value>::type* = nullptr>
 constexpr
 T
 binomial_coef_check(const T n, const T k)
@@ -46,7 +46,7 @@ noexcept
     return binomial_coef_recur(n,k);
 }
 
-template<typename T, typename std::enable_if<!std::is_integral<T>::value>::type* = nullptr>
+template<typename T, typename enable_if<!is_integral<T>::value>::type* = nullptr>
 constexpr
 T
 binomial_coef_check(const T n, const T k)

--- a/include/gcem_incl/factorial.hpp
+++ b/include/gcem_incl/factorial.hpp
@@ -55,7 +55,7 @@ noexcept
                          T(2432902008176640000) );
 }
 
-template<typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+template<typename T, typename enable_if<is_integral<T>::value>::type* = nullptr>
 constexpr
 T
 factorial_recur(const T x)
@@ -68,7 +68,7 @@ noexcept
                 x * factorial_recur(x - 1) );
 }
 
-template<typename T, typename std::enable_if<!std::is_integral<T>::value>::type* = nullptr>
+template<typename T, typename enable_if<!is_integral<T>::value>::type* = nullptr>
 constexpr
 T
 factorial_recur(const T x)

--- a/include/gcem_incl/find_exponent.hpp
+++ b/include/gcem_incl/find_exponent.hpp
@@ -34,15 +34,21 @@ llint_t
 find_exponent(const T x, const llint_t exponent)
 noexcept
 {
+    // Subtract one epsilon from T(1) so that values whose x*10^n product lands
+    // within one epsilon below 1.0 (e.g. 0.001L in 80-bit, which rounds to
+    // ~0.5 eps below 1.0 after scaling by 1000) are not pushed into the wrong
+    // decade.  One epsilon is the unique correct choice: it must be > 0.5 eps
+    // to catch 0.001L, and < 1.5 eps to avoid misclassifying the next
+    // representable value below the boundary.
     return( // < 1
-            x < T(1e-03)  ? \
+            x * T(1000) < T(1) - GCLIM<T>::epsilon() ? \
                 find_exponent(x * T(1e+04), exponent - llint_t(4)) :
-            x < T(1e-01)  ? \
+            x * T(10) < T(1) - GCLIM<T>::epsilon() ? \
                 find_exponent(x * T(1e+02), exponent - llint_t(2)) :
-            x < T(1)  ? \
+            x < T(1) - GCLIM<T>::epsilon() ? \
                 find_exponent(x * T(10), exponent - llint_t(1)) :
             // > 10
-            x > T(10) ? \
+            x >= T(10) ? \
                 find_exponent(x / T(10), exponent + llint_t(1)) :
             x > T(1e+02) ? \
                 find_exponent(x / T(1e+02), exponent + llint_t(2)) :
@@ -51,6 +57,7 @@ noexcept
             // else
                 exponent );
 }
+
 
 }
 

--- a/include/gcem_incl/gcd.hpp
+++ b/include/gcem_incl/gcd.hpp
@@ -33,7 +33,7 @@ noexcept
     return( b == T(0) ? a : gcd_recur(b, a % b) );
 }
 
-template<typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+template<typename T, typename enable_if<is_integral<T>::value>::type* = nullptr>
 constexpr
 T
 gcd_int_check(const T a, const T b)
@@ -42,7 +42,7 @@ noexcept
     return gcd_recur(a,b);
 }
 
-template<typename T, typename std::enable_if<!std::is_integral<T>::value>::type* = nullptr>
+template<typename T, typename enable_if<!is_integral<T>::value>::type* = nullptr>
 constexpr
 T
 gcd_int_check(const T a, const T b)

--- a/include/gcem_incl/gcem_limits.hpp
+++ b/include/gcem_incl/gcem_limits.hpp
@@ -1,0 +1,224 @@
+/*################################################################################
+  ##
+  ##   Copyright (C) 2016-2026 Keith O'Hara
+  ##
+  ##   This file is part of the GCE-Math C++ library.
+  ##
+  ##   Licensed under the Apache License, Version 2.0 (the "License");
+  ##   you may not use this file except in compliance with the License.
+  ##   You may obtain a copy of the License at
+  ##
+  ##       http://www.apache.org/licenses/LICENSE-2.0
+  ##
+  ##   Unless required by applicable law or agreed to in writing, software
+  ##   distributed under the License is distributed on an "AS IS" BASIS,
+  ##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ##   See the License for the specific language governing permissions and
+  ##   limitations under the License.
+  ##
+  ################################################################################*/
+
+/*
+ * Freestanding standin for <limits>.
+ * Provides gcem_limits, a minimal numeric_limits replacement.
+ */
+
+#if defined(GCEM_TRAITS_CUSTOM)
+
+    // Nothing to do - user provides definitions in namespace gcem.
+
+#elif defined(GCEM_TRAITS_BUILTIN)
+
+namespace gcem
+{
+
+    // gcem_limits - mirrors std::numeric_limits for the members gcem uses.
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L391
+    //
+    // infinity() and quiet_NaN() use __builtin_* intrinsics, tested via __has_builtin.
+    // min(), max(), and epsilon() use compiler-predefined macros (__FLT_MIN__, etc.)
+    // which expand to plain numeric literals - no function calls, no headers required.
+    //
+    // If your compiler lacks these builtins, use GCEM_TRAITS_CUSTOM instead.
+
+    template<typename T>
+    struct gcem_limits;
+
+// GCC < 10 defines __has_builtin but it is not usable as a preprocessor operator.
+// Provide a safe fallback so the check below works on all supported compilers.
+// Note: defining a __-prefixed name is technically reserved by the standard, but
+// this is a widely used pattern in freestanding code with no portable alternative.
+#ifndef __has_builtin
+  #define __has_builtin(x) 0
+  #define GCEM_UNDEF_HAS_BUILTIN
+#endif
+
+#if __has_builtin(__builtin_huge_valf) || defined(__GNUC__) || defined(__clang__)
+
+    template<>
+    struct gcem_limits<float> {
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1681
+        static constexpr float min()       noexcept { return __FLT_MIN__;           }
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1684
+        static constexpr float max()       noexcept { return __FLT_MAX__;           }
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1703
+        static constexpr float epsilon()   noexcept { return __FLT_EPSILON__;       }
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1722
+        static constexpr float infinity()  noexcept { return __builtin_huge_valf(); }
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1725
+        static constexpr float quiet_NaN() noexcept { return __builtin_nanf("");    }
+    };
+
+    template<>
+    struct gcem_limits<double> {
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1756
+        static constexpr double min()       noexcept { return __DBL_MIN__;          }
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1759
+        static constexpr double max()       noexcept { return __DBL_MAX__;          }
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1778
+        static constexpr double epsilon()   noexcept { return __DBL_EPSILON__;      }
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1797
+        static constexpr double infinity()  noexcept { return __builtin_huge_val(); }
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1800
+        static constexpr double quiet_NaN() noexcept { return __builtin_nan("");    }
+    };
+
+    template<>
+    struct gcem_limits<long double> {
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1831
+        static constexpr long double min()       noexcept { return __LDBL_MIN__;          }
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1834
+        static constexpr long double max()       noexcept { return __LDBL_MAX__;          }
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1853
+        static constexpr long double epsilon()   noexcept { return __LDBL_EPSILON__;      }
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1872
+        static constexpr long double infinity()  noexcept { return __builtin_huge_vall(); }
+        // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1875
+        static constexpr long double quiet_NaN() noexcept { return __builtin_nanl("");    }
+    };
+
+#else
+    #error "GCEM_TRAITS_BUILTIN: compiler does not support __builtin_huge_valf. " \
+           "Use GCEM_TRAITS_CUSTOM and provide your own gcem_limits specializations."
+#endif
+
+#ifdef GCEM_UNDEF_HAS_BUILTIN
+  #undef __has_builtin
+  #undef GCEM_UNDEF_HAS_BUILTIN
+#endif
+
+    // Integer specializations (min/max used by pow_integral.hpp)
+    // Uses unsigned arithmetic to compute signed limits without UB rather than
+    // INT_MAX/INT_MIN macros (which would require <climits>). Equivalent values,
+    // different implementation:
+    //   max() = all bits set except sign bit = (unsigned(-1) >> 1) cast to signed
+    //   min() = -max() - 1  (two's complement; mandated by C++20, de facto universal
+    //                        pre-C++20 -- this library intentionally requires it)
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1067
+    template<>
+    struct gcem_limits<int> {
+        static constexpr int max() noexcept { return static_cast<int>(static_cast<unsigned int>(-1) >> 1); }
+        static constexpr int min() noexcept { return -max() - 1; }
+    };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1206
+    template<>
+    struct gcem_limits<long> {
+        static constexpr long max() noexcept { return static_cast<long>(static_cast<unsigned long>(-1) >> 1); }
+        static constexpr long min() noexcept { return -max() - 1L; }
+    };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1346
+    template<>
+    struct gcem_limits<long long> {
+        static constexpr long long max() noexcept { return static_cast<long long>(static_cast<unsigned long long>(-1) >> 1); }
+        static constexpr long long min() noexcept { return -max() - 1LL; }
+    };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1134
+    template<>
+    struct gcem_limits<unsigned int> {
+        static constexpr unsigned int min() noexcept { return 0U; }
+        static constexpr unsigned int max() noexcept { return static_cast<unsigned int>(-1); }
+    };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1273
+    template<>
+    struct gcem_limits<unsigned long> {
+        static constexpr unsigned long min() noexcept { return 0UL; }
+        static constexpr unsigned long max() noexcept { return static_cast<unsigned long>(-1); }
+    };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1416
+    template<>
+    struct gcem_limits<unsigned long long> {
+        static constexpr unsigned long long min() noexcept { return 0ULL; }
+        static constexpr unsigned long long max() noexcept { return static_cast<unsigned long long>(-1); }
+    };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L858
+    template<>
+    struct gcem_limits<bool> {
+        static constexpr bool min() noexcept { return false; }
+        static constexpr bool max() noexcept { return true; }
+    };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L464
+    // char signedness is implementation-defined; the ternary detects it at compile time
+    // (mirrors __glibcxx_min/max(char) from libstdc++).
+    template<>
+    struct gcem_limits<char> {
+        static constexpr char max() noexcept {
+            return static_cast<char>(-1) < static_cast<char>(0)
+                ? static_cast<char>(static_cast<unsigned char>(-1) >> 1)
+                : static_cast<char>(static_cast<unsigned char>(-1));
+        }
+        static constexpr char min() noexcept {
+            return static_cast<char>(-1) < static_cast<char>(0) ? -max() - 1 : 0;
+        }
+    };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L531
+    template<>
+    struct gcem_limits<signed char> {
+        static constexpr signed char min() noexcept { return -__SCHAR_MAX__ - 1; }
+        static constexpr signed char max() noexcept { return __SCHAR_MAX__; }
+    };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L601
+    template<>
+    struct gcem_limits<unsigned char> {
+        static constexpr unsigned char min() noexcept { return 0; }
+        static constexpr unsigned char max() noexcept { return static_cast<unsigned char>(-1); }
+    };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L932
+    template<>
+    struct gcem_limits<short> {
+        static constexpr short min() noexcept { return -__SHRT_MAX__ - 1; }
+        static constexpr short max() noexcept { return __SHRT_MAX__; }
+    };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/limits#L1051
+    template<>
+    struct gcem_limits<unsigned short> {
+        static constexpr unsigned short min() noexcept { return 0; }
+        static constexpr unsigned short max() noexcept { return static_cast<unsigned short>(-1); }
+    };
+
+}  // namespace gcem
+
+#else  // default (stdlib)
+
+#include <limits>
+
+namespace gcem
+{
+
+    template<class T>
+    struct gcem_limits : std::numeric_limits<T> {};
+
+}  // namespace gcem
+
+#endif

--- a/include/gcem_incl/gcem_options.hpp
+++ b/include/gcem_incl/gcem_options.hpp
@@ -18,11 +18,9 @@
   ##
   ################################################################################*/
 
-#include <cstddef>      // size_t
-#include <limits>
-#include <type_traits>
-
-// undef some functions from math.h
+// undef some functions from math.h before including the trait headers so that
+// any platform macros already active do not mangle member function declarations
+// (e.g. gcem_limits<T>::min() / ::max()) or the <limits> include in stdlib mode.
 // see issue #29
 
 #ifdef abs
@@ -44,6 +42,9 @@
 #ifdef signbit
     #undef signbit
 #endif
+
+#include "gcem_type_traits.hpp"
+#include "gcem_limits.hpp"
 
 //
 // version
@@ -71,13 +72,13 @@ namespace gcem
     using llint_t = long long int;
 
     template<class T>
-    using GCLIM = std::numeric_limits<T>;
+    using GCLIM = gcem_limits<T>;
 
     template<typename T>
-    using return_t = typename std::conditional<std::is_integral<T>::value,double,T>::type;
+    using return_t = typename conditional<is_integral<T>::value,double,T>::type;
 
     template<typename ...T>
-    using common_t = typename std::common_type<T...>::type;
+    using common_t = typename common_type<T...>::type;
 
     template<typename ...T>
     using common_return_t = return_t<common_t<T...>>;

--- a/include/gcem_incl/gcem_type_traits.hpp
+++ b/include/gcem_incl/gcem_type_traits.hpp
@@ -1,0 +1,159 @@
+/*################################################################################
+  ##
+  ##   Copyright (C) 2016-2026 Keith O'Hara
+  ##
+  ##   This file is part of the GCE-Math C++ library.
+  ##
+  ##   Licensed under the Apache License, Version 2.0 (the "License");
+  ##   you may not use this file except in compliance with the License.
+  ##   You may obtain a copy of the License at
+  ##
+  ##       http://www.apache.org/licenses/LICENSE-2.0
+  ##
+  ##   Unless required by applicable law or agreed to in writing, software
+  ##   distributed under the License is distributed on an "AS IS" BASIS,
+  ##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ##   See the License for the specific language governing permissions and
+  ##   limitations under the License.
+  ##
+  ################################################################################*/
+
+/*
+ * Type traits dispatch.
+ *
+ * Three modes, selected by define before including gcem.hpp:
+ *
+ *   (default)            Use <utility>, <limits>, and <type_traits> from the hosted stdlib.
+ *   GCEM_TRAITS_BUILTIN  Self-contained implementation; no external includes.
+ *                        Suitable for freestanding / bare-metal targets
+ *                        using GCC or Clang.
+ *   GCEM_TRAITS_CUSTOM   Skip all definitions. The user must define the following
+ *                        in namespace gcem before including gcem.hpp:
+ *                          template<typename T> T&& declval() noexcept;
+ *                          template<class T> struct gcem_limits;
+ *                          template<bool B, typename T=void> struct enable_if;
+ *                          template<typename T> struct is_integral;
+ *                          template<typename T> struct is_signed;
+ *                          template<bool B, typename T, typename F> struct conditional;
+ *                          template<typename... T> struct common_type;
+ *
+ * ODR WARNING: The mode MUST be uniform across every translation unit in a
+ * binary. In BUILTIN mode gcem::enable_if, gcem::is_integral, etc. are
+ * independent struct definitions; in default mode they are aliases for the
+ * std:: types. Mixing modes across TUs violates the One Definition Rule and
+ * produces silent undefined behaviour. Enforce a consistent setting via a
+ * project-wide compiler flag (e.g. -DGCEM_TRAITS_BUILTIN) rather than
+ * per-file defines.
+ */
+
+#include "gcem_utility.hpp"  // required for declval, used by common_type in all three modes
+
+#if defined(GCEM_TRAITS_CUSTOM)
+
+    // Nothing to do - user provides definitions in namespace gcem.
+
+#elif defined(GCEM_TRAITS_BUILTIN)
+
+namespace gcem
+{
+
+    // enable_if
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/type_traits#L136
+    template<bool B, typename T = void>
+    struct enable_if {};
+
+    template<typename T>
+    struct enable_if<true, T> { using type = T; };
+
+    // is_integral
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/type_traits#L540
+    template<typename T> struct is_integral           { static constexpr bool value = false; };
+    template<> struct is_integral<bool>               { static constexpr bool value = true;  };
+    template<> struct is_integral<char>               { static constexpr bool value = true;  };
+    template<> struct is_integral<signed char>        { static constexpr bool value = true;  };
+    template<> struct is_integral<unsigned char>      { static constexpr bool value = true;  };
+    template<> struct is_integral<short>              { static constexpr bool value = true;  };
+    template<> struct is_integral<unsigned short>     { static constexpr bool value = true;  };
+    template<> struct is_integral<int>                { static constexpr bool value = true;  };
+    template<> struct is_integral<unsigned int>       { static constexpr bool value = true;  };
+    template<> struct is_integral<long>               { static constexpr bool value = true;  };
+    template<> struct is_integral<unsigned long>      { static constexpr bool value = true;  };
+    template<> struct is_integral<long long>          { static constexpr bool value = true;  };
+    template<> struct is_integral<unsigned long long> { static constexpr bool value = true;  };
+
+    template<typename T> struct is_integral<const T>          : is_integral<T> {};
+    template<typename T> struct is_integral<volatile T>       : is_integral<T> {};
+    template<typename T> struct is_integral<const volatile T> : is_integral<T> {};
+
+    // is_signed - T(-1) < T(0) works correctly for all arithmetic types in C++11.
+    // Diverges from std::is_signed for non-arithmetic types: std::is_signed gates
+    // this expression behind is_arithmetic and returns false for class types,
+    // whereas this will fail to compile if T(-1) is not a valid expression.
+    // Safe here because every call site constrains T to integral types.
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/type_traits#L1055
+    template<typename T>
+    struct is_signed { static constexpr bool value = T(-1) < T(0); };
+
+    // conditional
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/type_traits#L2565
+    template<bool B, typename T, typename F>
+    struct conditional { using type = F; };
+
+    template<typename T, typename F>
+    struct conditional<true, T, F> { using type = T; };
+
+    // remove_reference / remove_cv / decay - needed to strip T&& from ternary results
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/type_traits#L1859
+    template<typename T> struct remove_reference      { using type = T; };
+    template<typename T> struct remove_reference<T&>  { using type = T; };
+    template<typename T> struct remove_reference<T&&> { using type = T; };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/type_traits#L1793
+    template<typename T> struct remove_cv                   { using type = T; };
+    template<typename T> struct remove_cv<const T>          { using type = T; };
+    template<typename T> struct remove_cv<volatile T>       { using type = T; };
+    template<typename T> struct remove_cv<const volatile T> { using type = T; };
+
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/type_traits#L2491
+    template<typename T>
+    struct decay {
+        using type = typename remove_cv<typename remove_reference<T>::type>::type;
+    };
+
+    // common_type - variadic, peels one type at a time via ternary decay
+    // decay<> mirrors what std::common_type does: strips the && that declval introduces.
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/type_traits#L2575
+    template<typename... T> struct common_type;
+
+    template<typename T>
+    struct common_type<T> { using type = T; };
+
+    template<typename T1, typename T2>
+    struct common_type<T1, T2> {
+        using type = typename decay<decltype(true ? declval<T1>() : declval<T2>())>::type;
+    };
+
+    template<typename T1, typename T2, typename... Rest>
+    struct common_type<T1, T2, Rest...> {
+        using type = typename common_type<
+            typename decay<decltype(true ? declval<T1>() : declval<T2>())>::type, Rest...>::type;
+    };
+
+}  // namespace gcem
+
+#else  // default (stdlib)
+
+#include <type_traits>
+
+namespace gcem
+{
+
+    using std::enable_if;
+    using std::is_integral;
+    using std::is_signed;
+    using std::conditional;
+    using std::common_type;
+
+}  // namespace gcem
+
+#endif

--- a/include/gcem_incl/gcem_utility.hpp
+++ b/include/gcem_incl/gcem_utility.hpp
@@ -1,0 +1,52 @@
+/*################################################################################
+  ##
+  ##   Copyright (C) 2016-2026 Keith O'Hara
+  ##
+  ##   This file is part of the GCE-Math C++ library.
+  ##
+  ##   Licensed under the Apache License, Version 2.0 (the "License");
+  ##   you may not use this file except in compliance with the License.
+  ##   You may obtain a copy of the License at
+  ##
+  ##       http://www.apache.org/licenses/LICENSE-2.0
+  ##
+  ##   Unless required by applicable law or agreed to in writing, software
+  ##   distributed under the License is distributed on an "AS IS" BASIS,
+  ##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ##   See the License for the specific language governing permissions and
+  ##   limitations under the License.
+  ##
+  ################################################################################*/
+
+/*
+ * Freestanding standin for <utility>.
+ * Provides declval for use in unevaluated contexts (needed by common_type).
+ */
+
+#if defined(GCEM_TRAITS_CUSTOM)
+
+    // Nothing to do - user provides definitions in namespace gcem.
+
+#elif defined(GCEM_TRAITS_BUILTIN)
+
+namespace gcem
+{
+
+    // declval - for use in unevaluated contexts only; intentionally undefined
+    // Standardized in <utility>, but GCC defines it in <type_traits> which <utility> includes.
+    // https://github.com/gcc-mirror/gcc/blob/c39e4949694f15b4bd7f7b4de2769d853688508e/libstdc%2B%2B-v3/include/std/type_traits#L1076
+    template<typename T>
+    T&& declval() noexcept;
+
+}  // namespace gcem
+
+#else  // default (stdlib)
+
+#include <utility>
+
+namespace gcem
+{
+    using std::declval;
+}  // namespace gcem
+
+#endif

--- a/include/gcem_incl/log.hpp
+++ b/include/gcem_incl/log.hpp
@@ -155,7 +155,7 @@ return_t<T>
 log_integral_check(const T x)
 noexcept
 {
-    return( std::is_integral<T>::value ? \
+    return( is_integral<T>::value ? \
                 x == T(0) ? \
                     - GCLIM<return_t<T>>::infinity() :
                 x > T(1) ? \

--- a/include/gcem_incl/mantissa.hpp
+++ b/include/gcem_incl/mantissa.hpp
@@ -34,9 +34,13 @@ T
 mantissa(const T x)
 noexcept
 {
-    return( x < T(1) ? \
-                mantissa(x * T(10)) : 
-            x > T(10) ? \
+    // Mirror the one-epsilon tolerance used in find_exponent so that
+    // (mantissa(x), find_exponent(x)) stays a consistent decomposition of x.
+    return( x < T(1) - GCLIM<T>::epsilon() ? \
+                mantissa(x * T(10)) :
+            x < T(1) ? \
+                T(1) :
+            x >= T(10) ? \
                 mantissa(x / T(10)) :
             // else
                 x );

--- a/include/gcem_incl/pow.hpp
+++ b/include/gcem_incl/pow.hpp
@@ -38,7 +38,7 @@ noexcept
 }
 
 template<typename T1, typename T2, typename TC = common_t<T1,T2>, 
-         typename std::enable_if<!std::is_integral<T2>::value>::type* = nullptr>
+         typename enable_if<!is_integral<T2>::value>::type* = nullptr>
 constexpr
 TC
 pow_check(const T1 base, const T2 exp_term)
@@ -51,7 +51,7 @@ noexcept
 }
 
 template<typename T1, typename T2, typename TC = common_t<T1,T2>, 
-         typename std::enable_if<std::is_integral<T2>::value>::type* = nullptr>
+         typename enable_if<is_integral<T2>::value>::type* = nullptr>
 constexpr
 TC
 pow_check(const T1 base, const T2 exp_term)

--- a/include/gcem_incl/pow_integral.hpp
+++ b/include/gcem_incl/pow_integral.hpp
@@ -47,7 +47,7 @@ noexcept
                 (exp_term == T2(1) ? val*base : val) );
 }
 
-template<typename T1, typename T2, typename std::enable_if<std::is_signed<T2>::value>::type* = nullptr>
+template<typename T1, typename T2, typename enable_if<is_signed<T2>::value>::type* = nullptr>
 constexpr
 T1
 pow_integral_sgn_check(const T1 base, const T2 exp_term)
@@ -60,7 +60,7 @@ noexcept
                 pow_integral_compute_recur(base,T1(1),exp_term) );
 }
 
-template<typename T1, typename T2, typename std::enable_if<!std::is_signed<T2>::value>::type* = nullptr>
+template<typename T1, typename T2, typename enable_if<!is_signed<T2>::value>::type* = nullptr>
 constexpr
 T1
 pow_integral_sgn_check(const T1 base, const T2 exp_term)
@@ -92,7 +92,7 @@ noexcept
             pow_integral_sgn_check(base,exp_term) );
 }
 
-template<typename T1, typename T2, typename std::enable_if<std::is_integral<T2>::value>::type* = nullptr>
+template<typename T1, typename T2, typename enable_if<is_integral<T2>::value>::type* = nullptr>
 constexpr
 T1
 pow_integral_type_check(const T1 base, const T2 exp_term)
@@ -101,7 +101,7 @@ noexcept
     return pow_integral_compute(base,exp_term);
 }
 
-template<typename T1, typename T2, typename std::enable_if<!std::is_integral<T2>::value>::type* = nullptr>
+template<typename T1, typename T2, typename enable_if<!is_integral<T2>::value>::type* = nullptr>
 constexpr
 T1
 pow_integral_type_check(const T1 base, const T2 exp_term)

--- a/publish-ci-image.sh
+++ b/publish-ci-image.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Builds the CI image, pushes it to ghcr.io, and updates the image tag in
+# main.yml. Run this after editing the Dockerfile and verifying with
+# run-local-ci.sh.
+#
+# Usage: GHRCIO_TOKEN=<token> ./publish-ci-image.sh
+set -euo pipefail
+
+: "${GHRCIO_TOKEN:?GHRCIO_TOKEN is not set}"
+
+REGISTRY="ghcr.io"
+REPO="mitchellthompkins/gcem"
+IMAGE="${REGISTRY}/${REPO}/ci"
+WORKFLOW=".github/workflows/main.yml"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+TAG="$(sha256sum Dockerfile | cut -c1-12)"
+echo "Tag: $TAG"
+
+echo "Building ${IMAGE}:${TAG} ..."
+docker build -t "${IMAGE}:${TAG}" .
+
+echo "Logging in to ${REGISTRY} ..."
+echo "${GHRCIO_TOKEN}" | docker login "${REGISTRY}" -u MitchellThompkins --password-stdin
+
+echo "Pushing ${IMAGE}:${TAG} ..."
+docker push "${IMAGE}:${TAG}"
+
+echo "Updating $WORKFLOW ..."
+sed -i "s|${IMAGE}:[^[:space:]]*|${IMAGE}:${TAG}|g" "$WORKFLOW"
+
+echo "Done. Commit Dockerfile and $WORKFLOW together."

--- a/run-local-ci.sh
+++ b/run-local-ci.sh
@@ -34,15 +34,17 @@ for entry in "${MATRIX[@]}"; do
 
   coverage=$([[ "$build_type" == "Coverage" ]] && echo "1" || echo "")
 
-  if docker run --rm -v "${REPO}:/src" -w /src/tests "$IMAGE" bash -c "
-    export CC=$cc
-    export CXX=$cxx
-    export GCEM_CXX_STD=-std=c++$cxxstd
-    export COVERAGE=$coverage
-    make clean
-    make
-    ./run_tests
-  "; then
+  run_stdlib="
+    export CC=$cc CXX=$cxx GCEM_CXX_STD=-std=c++$cxxstd COVERAGE=$coverage
+    make clean && make && ./run_tests
+  "
+  run_builtin="
+    export CC=$cc CXX=$cxx GCEM_CXX_STD=-std=c++$cxxstd
+    make clean && GCEM_TRAITS_FLAGS=-DGCEM_TRAITS_BUILTIN make && ./run_tests
+  "
+
+  if docker run --rm -v "${REPO}:/src" -w /src/tests "$IMAGE" bash -c "$run_stdlib" \
+  && { [[ "$build_type" == "Coverage" ]] || docker run --rm -v "${REPO}:/src" -w /src/tests "$IMAGE" bash -c "$run_builtin"; }; then
     PASS+=("$name")
   else
     FAIL+=("$name")

--- a/run-local-ci.sh
+++ b/run-local-ci.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Mirrors the build-linux job in .github/workflows/main.yml.
+# Each matrix entry runs in its own fresh container, matching CI behaviour.
+set -euo pipefail
+
+IMAGE="gcem/ci:latest"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# name, build_type, cc, cxx, cxxstd
+MATRIX=(
+  "gcc12_cxx11          Release  gcc-12     g++-12     11"
+  "gcc12_cxx11_coverage Coverage gcc-12     g++-12     11"
+  "gcc9_cxx14           Release  gcc-9      g++-9      14"
+  "gcc10_cxx14          Release  gcc-10     g++-10     14"
+  "gcc11_cxx17          Release  gcc-11     g++-11     17"
+  "gcc11_cxx20          Release  gcc-11     g++-11     20"
+  "clang11_cxx11        Release  clang-11   clang++-11 11"
+  "clang11_cxx14        Release  clang-11   clang++-11 14"
+  "clang12_cxx14        Release  clang-12   clang++-12 14"
+  "clang13_cxx17        Release  clang-13   clang++-13 17"
+  "clang14_cxx20        Release  clang-14   clang++-14 20"
+  "gcc13_cxx23          Release  gcc-13     g++-13     23"
+  "clang16_cxx23        Release  clang-16   clang++-16 2b"
+)
+
+PASS=()
+FAIL=()
+
+for entry in "${MATRIX[@]}"; do
+  read -r name build_type cc cxx cxxstd <<< "$entry"
+
+  echo ""
+  echo "-> $name"
+
+  coverage=$([[ "$build_type" == "Coverage" ]] && echo "1" || echo "")
+
+  if docker run --rm -v "${REPO}:/src" -w /src/tests "$IMAGE" bash -c "
+    export CC=$cc
+    export CXX=$cxx
+    export GCEM_CXX_STD=-std=c++$cxxstd
+    export COVERAGE=$coverage
+    make clean
+    make
+    ./run_tests
+  "; then
+    PASS+=("$name")
+  else
+    FAIL+=("$name")
+  fi
+done
+
+echo ""
+for name in "${PASS[@]}"; do echo "PASS  $name"; done
+for name in "${FAIL[@]}"; do echo "FAIL  $name"; done
+echo ""
+
+[ ${#FAIL[@]} -eq 0 ]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -101,6 +101,9 @@ fabsl:
 factorial:
 	$(GCEM_MAKE_CALL)
 
+find_exponent:
+	$(GCEM_MAKE_CALL)
+
 fmod:
 	$(GCEM_MAKE_CALL)
 
@@ -138,6 +141,9 @@ log_binomial_coef:
 	$(GCEM_MAKE_CALL)
 
 log:
+	$(GCEM_MAKE_CALL)
+
+mantissa:
 	$(GCEM_MAKE_CALL)
 
 log1p:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,9 +11,13 @@ else
 endif
 
 ifneq (,$(findstring clang,$(CXX)))
-	OPT_FLAGS = -g -O0 -Wall -Wextra --coverage -fno-inline
+	OPT_FLAGS = -g -O0 -Wall -Wextra -fno-inline
 else
-	OPT_FLAGS = -g -O0 -Wall -Wextra --coverage -fno-inline -fno-inline-small-functions -fno-default-inline
+	OPT_FLAGS = -g -O0 -Wall -Wextra -fno-inline -fno-inline-small-functions -fno-default-inline
+endif
+
+ifneq (,$(COVERAGE))
+	OPT_FLAGS += --coverage
 endif
 
 ifneq ($(TRAVIS_CLANG_BUILD),)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -24,6 +24,10 @@ ifneq ($(TRAVIS_CLANG_BUILD),)
 	OPT_FLAGS += -DTRAVIS_CLANG_CXX
 endif
 
+ifneq ($(GCEM_TRAITS_FLAGS),)
+	OPT_FLAGS += $(GCEM_TRAITS_FLAGS)
+endif
+
 # source directories
 SDIR = .
 HEADER_DIR = $(SDIR)/../include

--- a/tests/find_exponent.cpp
+++ b/tests/find_exponent.cpp
@@ -1,0 +1,59 @@
+/*################################################################################
+  ##
+  ##   Copyright (C) 2016-2026 Keith O'Hara
+  ##
+  ##   This file is part of the GCE-Math C++ library.
+  ##
+  ##   Licensed under the Apache License, Version 2.0 (the "License");
+  ##   you may not use this file except in compliance with the License.
+  ##   You may obtain a copy of the License at
+  ##
+  ##       http://www.apache.org/licenses/LICENSE-2.0
+  ##
+  ##   Unless required by applicable law or agreed to in writing, software
+  ##   distributed under the License is distributed on an "AS IS" BASIS,
+  ##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ##   See the License for the specific language governing permissions and
+  ##   limitations under the License.
+  ##
+  ################################################################################*/
+
+#define TEST_PRINT_PRECISION_1 6
+#define TEST_PRINT_PRECISION_2 18
+
+#include "gcem_tests.hpp"
+
+int main()
+{
+    print_begin("find_exponent");
+
+    // long double: positive exponents
+
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  0.0L,  1.0L,    0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  0.0L,  5.0L,    0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  1.0L,  10.0L,   0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  1.0L,  11.0L,   0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  1.0L,  99.9L,   0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  2.0L,  100.0L,  0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  2.0L,  200.0L,  0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent,  2.0L,  123.45L, 0LL);
+
+    // long double: negative exponents, including the boundary cases (0.1L and
+    // 0.001L round toward zero in 80-bit, placing them just below their nominal
+    // decade boundary)
+
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -1.0L,  0.5L,    0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -1.0L,  0.1L,    0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -2.0L,  0.01L,   0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -3.0L,  0.001L,  0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -4.0L,  2.0e-4L, 0LL);
+
+    // double: verify the same boundary values work for double
+
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -1.0L,  0.1,     0LL);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::find_exponent, -3.0L,  0.001,   0LL);
+
+    print_final("find_exponent");
+
+    return 0;
+}

--- a/tests/gcem_tests.hpp
+++ b/tests/gcem_tests.hpp
@@ -19,6 +19,7 @@
   ################################################################################*/
 
 #include <cmath>
+#include <limits>
 #include <ios>
 #include <iostream>
 #include <iomanip>

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -1,6 +1,6 @@
 /*################################################################################
   ##
-  ##   Copyright (C) 2016-2024 Keith O'Hara
+  ##   Copyright (C) 2016-2026 Keith O'Hara
   ##
   ##   This file is part of the GCE-Math C++ library.
   ##
@@ -31,23 +31,25 @@ int main()
 
     //
 
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  0.5L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  0.00199900000000000208L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  1.0L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  1.5L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  41.5L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  123456789.5L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  0.001L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  0.1L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  0.5L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  0.00199900000000000208L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  1.0L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  1.5L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  41.5L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  123456789.5L);
 
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  0.0L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log, -1.0L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  0.0L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log, -1.0L);
 
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  1e-500L);
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  std::numeric_limits<long double>::min());
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  std::numeric_limits<double>::max());
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  1e-500L);
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  std::numeric_limits<long double>::min());
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  std::numeric_limits<double>::max());
     
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log, -std::numeric_limits<long double>::infinity());
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  std::numeric_limits<long double>::infinity());
-    GCEM_TEST_COMPARE_VALS(gcem::log,std::log,  std::numeric_limits<long double>::quiet_NaN());
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log, -std::numeric_limits<long double>::infinity());
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  std::numeric_limits<long double>::infinity());
+    GCEM_TEST_COMPARE_VALS(gcem::log, std::log,  std::numeric_limits<long double>::quiet_NaN());
 
     //
 

--- a/tests/mantissa.cpp
+++ b/tests/mantissa.cpp
@@ -1,0 +1,56 @@
+/*################################################################################
+  ##
+  ##   Copyright (C) 2016-2026 Keith O'Hara
+  ##
+  ##   This file is part of the GCE-Math C++ library.
+  ##
+  ##   Licensed under the Apache License, Version 2.0 (the "License");
+  ##   you may not use this file except in compliance with the License.
+  ##   You may obtain a copy of the License at
+  ##
+  ##       http://www.apache.org/licenses/LICENSE-2.0
+  ##
+  ##   Unless required by applicable law or agreed to in writing, software
+  ##   distributed under the License is distributed on an "AS IS" BASIS,
+  ##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ##   See the License for the specific language governing permissions and
+  ##   limitations under the License.
+  ##
+  ################################################################################*/
+
+#define TEST_PRINT_PRECISION_1 6
+#define TEST_PRINT_PRECISION_2 18
+
+#include "gcem_tests.hpp"
+
+int main()
+{
+    print_begin("mantissa");
+
+    // long double: values whose mantissa is unambiguous
+
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  1.0L,  1.0L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  5.0L,  5.0L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  9.99L, 9.99L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  2.0L,  20.0L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  1.2345L, 123.45L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  5.0L,  0.5L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  2.0L,  0.02L);
+
+    // long double: boundary cases withing the ULP-tolerant snap.  0.1L and
+    // 0.001L round toward zero in 80-bit, so repeated scaling by 10 lands just
+    // below 1.0 rather than exactly on it.  mantissa() must snap these to 1.0
+    // to stay consistent with find_exponent().
+
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  1.0L,  0.1L);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  1.0L,  0.001L);
+
+    // double: verify the same boundary values work for double
+
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  1.0,   0.1);
+    GCEM_TEST_EXPECTED_VAL(gcem::internal::mantissa,  1.0,   0.001);
+
+    print_final("mantissa");
+
+    return 0;
+}

--- a/tests/pow.cpp
+++ b/tests/pow.cpp
@@ -38,6 +38,10 @@ int main()
     // int versions
     GCEM_TEST_COMPARE_VALS(gcem::pow,std::pow, 0.5L,  2L);
     GCEM_TEST_COMPARE_VALS(gcem::pow,std::pow, 41.5L, 7L);
+
+    // sub-int exponent types (exercises gcem_limits<short>, gcem_limits<signed char>)
+    GCEM_TEST_COMPARE_VALS(gcem::pow,std::pow, 2.0L, short{3});
+    GCEM_TEST_COMPARE_VALS(gcem::pow,std::pow, 2.0L, static_cast<signed char>(4));
     
     GCEM_TEST_COMPARE_VALS(gcem::pow,std::pow,  std::numeric_limits<long double>::quiet_NaN(), 2);
     GCEM_TEST_COMPARE_VALS(gcem::pow,std::pow,  2, std::numeric_limits<long double>::quiet_NaN());

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -1,4 +1,6 @@
 
+set -e
+
 for t in ./*.test; do
    "$t"
 done


### PR DESCRIPTION
# Add optional no-stdlib (builtin traits) mode

## Summary

This adds an _completely_ opt-in `-nostdlib` compliant variant of `gcem`. That is; it adds a variant that does not require stdlib support.

There are some freestanding/bare-metal platforms, almost entirely embedded, that build without stdlib support. Today `gcem` relies on `<utility>`, `<type_traits>`, and `<limits>` which makes it impossible to use in those environments. This library is _really_ powerful for those platforms b/c you can offload a lot of math into the compiler. I worked on [consteig](https://github.com/MitchellThompkins/consteig) which is targeted largely towards those environments and specifically had to write all of the constexpr math functions from scratch instead of using this library (although the change this PR introduces would allow me to use this dependency in https://github.com/MitchellThompkins/consteig/pull/62).

Again, the default behavior is unchanged so existing users see no difference.

**Note that this PR builds on these two**:

1. https://github.com/kthohr/gcem/pull/60
2. https://github.com/kthohr/gcem/pull/61

(1) is a good fix I think, and (2) is a necessary fix in order to make this testing consistent.

## Modes

Selected by defining one of the following before including `gcem.hpp`:

| Mode | Behavior |
|---|---|
| *(default)* | Uses `<utility>`, `<type_traits>`, `<limits>` from the hosted stdlib. Same as today. |
| `GCEM_TRAITS_BUILTIN` | Self-contained implementation using `__builtin_*` intrinsics and compiler-predefined macros. Requires GCC or Clang. Should work with modern MSVC (but I've never seen MSVC compiled freestanding). |
| `GCEM_TRAITS_CUSTOM` | Skips all definitions; user supplies their own in `namespace gcem`. Provides an alternative for unusual or proprietary toolchains (like IAR). |

## stdlib stand-in changes

- **`include/gcem_incl/gcem_type_traits.hpp`**: `enable_if`, `is_integral`, `is_signed`, `conditional`, `common_type`, plus the supporting `remove_reference` / `remove_cv` / `decay`.
- **`include/gcem_incl/gcem_limits.hpp`**: `gcem_limits<T>` for `float`, `double`, `long double` (via `__builtin_huge_val*` / `__builtin_nan*` / `__FLT_*__` macros), and for every fundamental integer type that `is_integral` accepts: `bool`, `char`, `signed/unsigned char`, `short`/`unsigned short`, `int`/`unsigned int`, `long`/`unsigned long`, `long long`/`unsigned long long`. This means `<cstdint>` typedefs (`uint8_t`, `int16_t`, `size_t`, etc.) all resolve via the existing fundamental-type specializations so there is no extra work needed at call sites.
- **`include/gcem_incl/gcem_utility.hpp`**: `declval` for use in `common_type`'s unevaluated context.

Each replacement carries a permalink back to the corresponding line in libstdc++ (pinned to a specific gcc-mirror commit) so reviewers and future maintainers can verify behavior matches std semantics. I tried my best to match these up.

## gcem internal changes

- `gcem_options.hpp` no longer includes `<cstddef>`, `<limits>`, or `<type_traits>` directly. Instead it pulls in the new headers, which dispatch to stdlib or builtins based on mode.
- Call sites that referenced `std::is_integral`, `std::enable_if`, `std::is_signed`, `std::numeric_limits`, etc. now use the unqualified `gcem::` versions: `binomial_coef.hpp`, `factorial.hpp`, `gcd.hpp`, `log.hpp`, `pow.hpp`, `pow_integral.hpp`. In default mode these are `using` aliases for the std versions, so the behavior is identical.
- `GCLIM<T>` is now `gcem::gcem_limits<T>` instead of `std::numeric_limits<T>`.

## CI changes

- Linux and macOS jobs each gained a second test step that runs the suite with `GCEM_TRAITS_FLAGS="-DGCEM_TRAITS_BUILTIN"`. The builtin step is skipped for Coverage builds to avoid clobbering coverage data.
- `tests/Makefile` forwards `GCEM_TRAITS_FLAGS` to the compiler.
- `run-local-ci.sh` mirrors the CI matrix so both modes can be exercised locally.
